### PR TITLE
Corregir orden del nombre completo: base + tipo + sabor + tamaño

### DIFF
--- a/src/components/reposicion/ReposicionCard.tsx
+++ b/src/components/reposicion/ReposicionCard.tsx
@@ -175,7 +175,14 @@ export function ReposicionCard({
             className="border-t border-border"
           >
             <div className="divide-y divide-border">
-              {variantes.map(({ item, variante }) => (
+              {variantes.map(({ item, variante }) => {
+                // El header de la card ya muestra productoBase.nombre, así que acá
+                // se arma solo la parte de variante (tipo+sabor+tamaño) para no
+                // repetir el nombre base que nombreCompleto ya incluye.
+                const descriptorVariante =
+                  [variante.tipo, variante.sabor, variante.tamano].filter(Boolean).join(" ") ||
+                  variante.nombreCompleto;
+                return (
                 <div key={item.id} className="p-3 sm:p-4">
                   <div className="space-y-3">
                     <div className="flex items-start gap-3">
@@ -188,14 +195,9 @@ export function ReposicionCard({
                       )}
                       <div className="flex-1 min-w-0">
                         <p className="text-subhead font-semibold text-fg leading-tight">
-                          {variante.nombreCompleto}
+                          {descriptorVariante}
                         </p>
                         <div className="flex items-center gap-2 mt-1.5 flex-wrap">
-                          {variante.tamano && (
-                            <span className="text-footnote text-fg-secondary">
-                              {variante.tamano}
-                            </span>
-                          )}
                           {item.estado === "repuesto" && <Badge variant="success">REPUESTO</Badge>}
                           {item.estado === "sin_stock" && <Badge variant="danger">SIN STOCK</Badge>}
                           {item.estado === "pendiente" && <Badge variant="default">PENDIENTE</Badge>}
@@ -305,7 +307,8 @@ export function ReposicionCard({
                     </div>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           </m.div>
         )}

--- a/src/components/scanner/ExpiryQuickSheet.tsx
+++ b/src/components/scanner/ExpiryQuickSheet.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 
 export interface ExpiryQuickSheetProps {
   isOpen: boolean;
-  producto: { nombre: string; tamano?: string } | null;
+  producto: { nombre: string } | null;
   onSubmit: (v: { fecha: Date; cantidad?: number; lote?: string }) => void;
   onClose: () => void;
   isPending: boolean;
@@ -63,9 +63,6 @@ export function ExpiryQuickSheet({
         {producto && (
           <div className="p-3 rounded-field bg-surface-2">
             <p className="text-headline text-fg">{producto.nombre}</p>
-            {producto.tamano && (
-              <p className="text-footnote text-fg-secondary">{producto.tamano}</p>
-            )}
           </div>
         )}
 

--- a/src/components/scanner/QuickAdjustCard.tsx
+++ b/src/components/scanner/QuickAdjustCard.tsx
@@ -8,7 +8,6 @@ import { useRef } from "react";
 
 export interface QuickAdjustCardProps {
   nombre: string;
-  tamano?: string;
   cantidad: number;
   deadline: number;
   onIncrement: () => void;
@@ -26,7 +25,6 @@ const CHIPS = [2, 3, 6, 12];
  */
 export function QuickAdjustCard({
   nombre,
-  tamano,
   cantidad,
   deadline,
   onIncrement,
@@ -63,7 +61,6 @@ export function QuickAdjustCard({
             <div className="flex items-start justify-between gap-2 mb-3">
               <div className="min-w-0">
                 <p className="text-headline text-fg truncate">{nombre}</p>
-                {tamano && <p className="text-footnote text-fg-secondary">{tamano}</p>}
               </div>
               <button
                 onClick={onUndo}

--- a/src/components/scanner/ScanFlow.tsx
+++ b/src/components/scanner/ScanFlow.tsx
@@ -200,7 +200,6 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
           state.mode === "adjusting" ? (
             <QuickAdjustCard
               nombre={state.card.nombre}
-              tamano={state.card.tamano}
               cantidad={state.card.cantidad}
               deadline={state.card.deadline}
               onIncrement={() => dispatch({ type: "SET_QTY", cantidad: state.card.cantidad + 1 })}
@@ -216,10 +215,7 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
         isOpen={state.mode === "dating"}
         producto={
           state.mode === "dating"
-            ? {
-                nombre: state.producto.variante.nombreCompleto,
-                tamano: state.producto.variante.tamano,
-              }
+            ? { nombre: state.producto.variante.nombreCompleto }
             : null
         }
         onSubmit={handleVencimientoSubmit}

--- a/src/components/scanner/scanFlowMachine.ts
+++ b/src/components/scanner/scanFlowMachine.ts
@@ -21,7 +21,6 @@ export interface AdjustCard {
   varianteId: string;
   ean: string;
   nombre: string;
-  tamano?: string;
   /** Cantidad total del item en la lista (incluye merge con un pendiente previo). */
   cantidad: number;
   /** Cantidad que el item pendiente ya tenía antes de este escaneo (0 = no existía). */
@@ -142,7 +141,6 @@ export function scanFlowReduce(
               varianteId: event.item.varianteId,
               ean: event.ean,
               nombre: event.producto.variante.nombreCompleto,
-              tamano: event.producto.variante.tamano,
               cantidad: event.item.cantidad,
               prevCantidad: Math.max(0, event.item.cantidad - 1),
               deadline: ctx.now() + ADJUST_TIMEOUT_MS,

--- a/src/components/search/ProductResultRow.tsx
+++ b/src/components/search/ProductResultRow.tsx
@@ -9,7 +9,6 @@ export interface ProductoRowData {
   varianteId: string;
   nombre: string;
   marca?: string;
-  tamano?: string;
 }
 
 export interface ProductResultRowProps {
@@ -37,10 +36,8 @@ function ProductResultRowImpl({
       </div>
       <div className="min-w-0 flex-1">
         <p className="text-body font-medium text-fg truncate">{producto.nombre}</p>
-        {(producto.marca || producto.tamano) && (
-          <p className="text-footnote text-fg-secondary truncate">
-            {[producto.marca, producto.tamano].filter(Boolean).join(" · ")}
-          </p>
+        {producto.marca && (
+          <p className="text-footnote text-fg-secondary truncate">{producto.marca}</p>
         )}
       </div>
 

--- a/src/components/search/ProductSearchSheet.tsx
+++ b/src/components/search/ProductSearchSheet.tsx
@@ -214,11 +214,7 @@ export function ProductSearchSheet({ isOpen, onClose, mode }: ProductSearchSheet
 
       <ExpiryQuickSheet
         isOpen={pendingVencimiento !== null}
-        producto={
-          pendingVencimiento
-            ? { nombre: pendingVencimiento.nombre, tamano: pendingVencimiento.tamano }
-            : null
-        }
+        producto={pendingVencimiento ? { nombre: pendingVencimiento.nombre } : null}
         onSubmit={handleVencimientoSubmit}
         onClose={() => setPendingVencimiento(null)}
         isPending={agregarVencimiento.isPending}

--- a/src/components/vencimiento/VencimientoItem.tsx
+++ b/src/components/vencimiento/VencimientoItem.tsx
@@ -72,11 +72,6 @@ export function VencimientoItem({ item, variante, onEdit }: VencimientoItemProps
             <p className="text-headline text-fg leading-tight">
               {variante.nombreCompleto}
             </p>
-            {variante.tamano && (
-              <p className="text-footnote text-fg-secondary mt-0.5 truncate">
-                {variante.tamano}
-              </p>
-            )}
           </div>
         </div>
 

--- a/src/services/__tests__/catalogo.test.ts
+++ b/src/services/__tests__/catalogo.test.ts
@@ -111,6 +111,43 @@ describe("crearProductoManual", () => {
     expect(fromMock).toHaveBeenCalledTimes(3);
   });
 
+  it("arma nombre_completo como base + tipo + sabor + tamaño", async () => {
+    const { crearProductoManual } = await import("@/services/catalogo");
+    const dtoConSabor = {
+      ean: "7777777777777",
+      productoBase: { nombre: "Yerba", marca: "Playadito", categoria: "Almacén" },
+      variante: { tipo: "Con Palo", sabor: "Suave", tamano: "1kg" },
+    };
+    let payloadInsertado: Record<string, unknown> | undefined;
+    fromMock.mockImplementation((tabla: string) => {
+      if (tabla === "producto_variantes") {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+          insert: (payload: Record<string, unknown>) => {
+            payloadInsertado = payload;
+            return {
+              select: () => ({
+                single: async () => ({
+                  data: { ...payload, id: "variante-nueva", created_at: "2026-01-01T00:00:00Z" },
+                  error: null,
+                }),
+              }),
+            };
+          },
+        };
+      }
+      return {
+        select: () => ({
+          eq: () => ({ eq: () => ({ maybeSingle: async () => ({ data: baseRow, error: null }) }) }),
+        }),
+      };
+    });
+
+    await crearProductoManual(dtoConSabor);
+
+    expect(payloadInsertado?.nombre_completo).toBe("Yerba Con Palo Suave 1kg");
+  });
+
   it("crea un producto base nuevo si no existe ninguno con ese nombre+marca", async () => {
     const { crearProductoManual } = await import("@/services/catalogo");
     const baseNuevaRow = { ...baseRow, id: "base-nueva", nombre: "Yerba", marca: "Playadito" };

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -218,7 +218,12 @@ export async function crearProductoManual(
     baseRow = data as ProductoBaseRow;
   }
 
-  const nombreCompleto = [dto.variante.tipo, dto.variante.tamano, dto.variante.sabor]
+  const nombreCompleto = [
+    dto.productoBase.nombre,
+    dto.variante.tipo,
+    dto.variante.sabor,
+    dto.variante.tamano,
+  ]
     .filter(Boolean)
     .join(" ")
     .trim();
@@ -228,7 +233,7 @@ export async function crearProductoManual(
     .insert({
       producto_base_id: baseRow.id,
       codigo_barras: dto.ean.trim(),
-      nombre_completo: nombreCompleto || dto.productoBase.nombre,
+      nombre_completo: nombreCompleto,
       tipo: dto.variante.tipo?.trim(),
       tamano: dto.variante.tamano?.trim() || null,
       sabor: dto.variante.sabor?.trim(),


### PR DESCRIPTION
nombre_completo se armaba como tipo+tamaño+sabor sin el nombre base.
Ahora sigue el orden esperado y se limpian las duplicaciones de
tamaño/nombre que quedaban en la UI como consecuencia del cambio.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Py4dGLa12QbDZjYtv9NUzr