### PR TITLE
Agrega cola offline para reposición y vencimiento, corrige merge-on-add

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@upstash/redis": "^1.35.6",
         "framer-motion": "^12.23.24",
         "html5-qrcode": "^2.3.8",
+        "idb-keyval": "^6.2.6",
         "lucide-react": "^0.553.0",
         "next": "^16.0.8",
         "postcss": "^8.5.6",
@@ -8366,6 +8367,12 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.6.tgz",
+      "integrity": "sha512-FY64UEhw+5liMzMQ1R9Mw6AF0+wyBrg1CIA1z4CjI/EvT5ty/SvQcWZgd8s9sgaNhX10Y8UzScTh89tEAls5nA==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@upstash/redis": "^1.35.6",
     "framer-motion": "^12.23.24",
     "html5-qrcode": "^2.3.8",
+    "idb-keyval": "^6.2.6",
     "lucide-react": "^0.553.0",
     "next": "^16.0.8",
     "postcss": "^8.5.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Toaster } from "react-hot-toast";
 import "./globals.css";
+import OutboxProvider from "@/components/OutboxProvider";
 import PWAProvider from "./PWAProvider";
 import { QueryProvider } from "./QueryProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -102,6 +103,7 @@ export default function RootLayout({
         <QueryProvider>
           <ThemeProvider>
             <PWAProvider />
+            <OutboxProvider />
             <Toaster
               position="top-center"
               containerStyle={{ top: "calc(env(safe-area-inset-top, 0px) + 64px)" }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { OutboxBadge } from "@/components/OutboxBadge";
 import { ScanFlow } from "@/components/scanner/ScanFlow";
 import { ProductSearchSheet } from "@/components/search/ProductSearchSheet";
 import { AppShell } from "@/components/shell/AppShell";
@@ -91,6 +92,7 @@ function HomePageContent() {
                 >
                   <History size={22} />
                 </Link>
+                <OutboxBadge />
                 <ThemeToggle />
               </>
             }

--- a/src/components/OutboxBadge.tsx
+++ b/src/components/OutboxBadge.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useOutboxStore } from "@/store/outbox";
+import { CloudOff } from "lucide-react";
+
+/** Indicador discreto de cambios guardados localmente a la espera de conexión. */
+export function OutboxBadge() {
+  const pendingCount = useOutboxStore((s) => s.pendingCount);
+  if (pendingCount === 0) return null;
+
+  return (
+    <div
+      className="flex items-center gap-1 h-8 px-2.5 rounded-full bg-surface-2 text-fg-tertiary text-caption font-semibold"
+      title={`${pendingCount} cambio${pendingCount === 1 ? "" : "s"} sin sincronizar`}
+    >
+      <CloudOff size={14} />
+      <span className="tabular-nums">{pendingCount}</span>
+    </div>
+  );
+}

--- a/src/components/OutboxProvider.tsx
+++ b/src/components/OutboxProvider.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { countPending, processQueue } from "@/lib/outbox/outbox";
+import { useOutboxStore } from "@/store/outbox";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import toast from "react-hot-toast";
+
+/**
+ * Sincroniza la cola offline apenas hay conexión: al montar (por si quedó
+ * algo pendiente de una sesión anterior) y en cada evento `online`. No
+ * renderiza nada — es lógica pura de ciclo de vida.
+ */
+export default function OutboxProvider() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    countPending().then((n) => useOutboxStore.getState().setPendingCount(n));
+
+    const sincronizar = async () => {
+      const antes = await countPending();
+      if (antes === 0) return;
+      await processQueue();
+      const despues = await countPending();
+      queryClient.invalidateQueries({ queryKey: ["reposicion"] });
+      queryClient.invalidateQueries({ queryKey: ["vencimiento"] });
+      if (despues < antes) {
+        toast.success(
+          antes - despues === 1
+            ? "1 cambio sincronizado"
+            : `${antes - despues} cambios sincronizados`,
+          { duration: 2500 }
+        );
+      }
+    };
+
+    if (navigator.onLine) sincronizar();
+    window.addEventListener("online", sincronizar);
+    return () => window.removeEventListener("online", sincronizar);
+  }, [queryClient]);
+
+  return null;
+}

--- a/src/components/reposicion/ReposicionList.tsx
+++ b/src/components/reposicion/ReposicionList.tsx
@@ -122,8 +122,8 @@ export function ReposicionList() {
       toast.success("Lista guardada correctamente");
       setShowSaveSheet(false);
       setExpandedCards(new Set());
-    } catch {
-      toast.error("Error al guardar la lista");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Error al guardar la lista");
     }
   };
 

--- a/src/hooks/__tests__/useReposicion.test.tsx
+++ b/src/hooks/__tests__/useReposicion.test.tsx
@@ -15,6 +15,11 @@ vi.mock("@/services/reposicion", () => ({
   obtenerEstadisticas: vi.fn(),
 }));
 
+// El módulo del outbox (usado por useReposicion para el soporte offline)
+// importa también @/services/vencimiento, que a su vez importa el cliente
+// real de Supabase. Se mockea acá para no depender de env vars en este test.
+vi.mock("@/lib/supabase", () => ({ supabase: {} }));
+
 vi.mock("react-hot-toast", () => {
   let ultimoRenderProp: ((t: { id: string }) => React.ReactNode) | null = null;
   const toastFn = Object.assign(

--- a/src/hooks/useReposicion.tsx
+++ b/src/hooks/useReposicion.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
+import { ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
+import { crearTempId } from "@/lib/outbox/types";
 import * as reposicionService from "@/services/reposicion";
 import { EstadoReposicion, ItemReposicion } from "@/types";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import toast from "react-hot-toast";
 
@@ -14,20 +17,96 @@ export function useReposicionItems() {
   return useQuery({ queryKey: ITEMS_KEY, queryFn: reposicionService.listarItems });
 }
 
+/**
+ * Reproduce localmente el merge-on-add del servicio (mismo criterio: cualquier
+ * estado de la misma variante se reabre a pendiente) cuando no hay red, y
+ * encola la operación real para cuando vuelva la conexión.
+ */
+async function agregarOffline(
+  queryClient: QueryClient,
+  varianteId: string,
+  cantidad: number
+): Promise<ItemReposicion> {
+  const actuales = queryClient.getQueryData<ItemReposicion[]>(ITEMS_KEY) ?? [];
+  const existente = actuales.find((i) => i.varianteId === varianteId);
+  const ahora = new Date();
+
+  if (existente) {
+    const actualizado: ItemReposicion = {
+      ...existente,
+      cantidad: existente.cantidad + cantidad,
+      estado: "pendiente",
+      actualizadoAt: ahora,
+    };
+    await enqueueOperation("reposicion.actualizarCantidad", {
+      id: existente.id,
+      cantidad: actualizado.cantidad,
+    });
+    if (existente.estado !== "pendiente") {
+      await enqueueOperation("reposicion.cambiarEstado", {
+        id: existente.id,
+        estado: "pendiente",
+      });
+    }
+    return actualizado;
+  }
+
+  const tempId = crearTempId();
+  const nuevo: ItemReposicion = {
+    id: tempId,
+    varianteId,
+    cantidad,
+    estado: "pendiente",
+    agregadoAt: ahora,
+    actualizadoAt: ahora,
+  };
+  await enqueueOperation("reposicion.agregarItem", { tempId, varianteId, cantidad });
+  return nuevo;
+}
+
 export function useAgregarReposicionItem() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ varianteId, cantidad }: { varianteId: string; cantidad: number }) =>
-      reposicionService.agregarItem(varianteId, cantidad),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
+    networkMode: "always",
+    mutationFn: async ({
+      varianteId,
+      cantidad,
+    }: {
+      varianteId: string;
+      cantidad: number;
+    }): Promise<ItemReposicion> => {
+      if (isOnline()) {
+        try {
+          return await reposicionService.agregarItem(varianteId, cantidad);
+        } catch (err) {
+          if (!isNetworkError(err)) throw err;
+        }
+      }
+      return agregarOffline(queryClient, varianteId, cantidad);
+    },
+    onSuccess: (item) => {
+      queryClient.setQueryData<ItemReposicion[]>(ITEMS_KEY, (items) => {
+        const actuales = items ?? [];
+        const yaEstaba = actuales.some((i) => i.id === item.id);
+        return yaEstaba
+          ? actuales.map((i) => (i.id === item.id ? item : i))
+          : [item, ...actuales];
+      });
+    },
   });
 }
 
 export function useActualizarCantidadReposicion() {
   const queryClient = useQueryClient();
   return useMutation({
+    networkMode: "always",
     mutationFn: ({ id, cantidad }: { id: string; cantidad: number }) =>
-      reposicionService.actualizarCantidad(id, cantidad),
+      ejecutarOEncolar(
+        id,
+        () => reposicionService.actualizarCantidad(id, cantidad),
+        () => enqueueOperation("reposicion.actualizarCantidad", { id, cantidad }),
+        null as ItemReposicion | null
+      ),
     onMutate: async ({ id, cantidad }) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemReposicion[]>(ITEMS_KEY);
@@ -39,15 +118,20 @@ export function useActualizarCantidadReposicion() {
     onError: (_err, _vars, context) => {
       if (context?.previous) queryClient.setQueryData(ITEMS_KEY, context.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
   });
 }
 
 export function useCambiarEstadoReposicion() {
   const queryClient = useQueryClient();
   return useMutation({
+    networkMode: "always",
     mutationFn: ({ id, estado }: { id: string; estado: EstadoReposicion }) =>
-      reposicionService.cambiarEstado(id, estado),
+      ejecutarOEncolar(
+        id,
+        () => reposicionService.cambiarEstado(id, estado),
+        () => enqueueOperation("reposicion.cambiarEstado", { id, estado }),
+        null as ItemReposicion | null
+      ),
     onMutate: async ({ id, estado }) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemReposicion[]>(ITEMS_KEY);
@@ -59,15 +143,19 @@ export function useCambiarEstadoReposicion() {
     onError: (_err, _vars, context) => {
       if (context?.previous) queryClient.setQueryData(ITEMS_KEY, context.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
   });
 }
 
 function useEliminarReposicionItem() {
-  const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => reposicionService.eliminarItem(id),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
+    networkMode: "always",
+    mutationFn: (id: string) =>
+      ejecutarOEncolar(
+        id,
+        () => reposicionService.eliminarItem(id),
+        () => enqueueOperation("reposicion.eliminarItem", { id }),
+        undefined as void
+      ),
   });
 }
 
@@ -127,7 +215,14 @@ export function useDecrementarReposicion() {
 export function useEliminarReposicionItemDirecto() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => reposicionService.eliminarItem(id),
+    networkMode: "always",
+    mutationFn: (id: string) =>
+      ejecutarOEncolar(
+        id,
+        () => reposicionService.eliminarItem(id),
+        () => enqueueOperation("reposicion.eliminarItem", { id }),
+        undefined as void
+      ),
     onMutate: async (id) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemReposicion[]>(ITEMS_KEY);
@@ -139,14 +234,21 @@ export function useEliminarReposicionItemDirecto() {
     onError: (_err, _id, context) => {
       if (context?.previous) queryClient.setQueryData(ITEMS_KEY, context.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
   });
 }
 
 export function useGuardarListaReposicion() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => reposicionService.guardarListaActual(),
+    networkMode: "always",
+    mutationFn: async () => {
+      if (!isOnline()) {
+        throw new Error(
+          "Necesitás conexión a internet para guardar la lista y cerrar el turno."
+        );
+      }
+      return reposicionService.guardarListaActual();
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ITEMS_KEY });
       queryClient.invalidateQueries({ queryKey: HISTORIAL_KEY });

--- a/src/hooks/useVencimiento.tsx
+++ b/src/hooks/useVencimiento.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
+import { ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
+import { crearTempId } from "@/lib/outbox/types";
+import { calcularNivelAlerta } from "@/lib/utils";
 import * as vencimientoService from "@/services/vencimiento";
 import { ItemVencimientoConAlerta } from "@/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -15,7 +19,8 @@ export function useVencimientoItems() {
 export function useAgregarVencimientoItem() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({
+    networkMode: "always",
+    mutationFn: async ({
       varianteId,
       fechaVencimiento,
       cantidad,
@@ -25,36 +30,95 @@ export function useAgregarVencimientoItem() {
       fechaVencimiento: Date;
       cantidad?: number;
       lote?: string;
-    }) => vencimientoService.agregarItem(varianteId, fechaVencimiento, cantidad, lote),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
+    }): Promise<ItemVencimientoConAlerta> => {
+      if (isOnline()) {
+        try {
+          return await vencimientoService.agregarItem(
+            varianteId,
+            fechaVencimiento,
+            cantidad,
+            lote
+          );
+        } catch (err) {
+          if (!isNetworkError(err)) throw err;
+        }
+      }
+
+      const tempId = crearTempId();
+      await enqueueOperation("vencimiento.agregarItem", {
+        tempId,
+        varianteId,
+        fechaVencimiento: fechaVencimiento.toISOString().slice(0, 10),
+        cantidad,
+        lote,
+      });
+      return {
+        id: tempId,
+        varianteId,
+        fechaVencimiento,
+        cantidad,
+        lote,
+        estado: "pendiente",
+        agregadoAt: new Date(),
+        alertaNivel: calcularNivelAlerta(fechaVencimiento),
+      };
+    },
+    onSuccess: (item) => {
+      queryClient.setQueryData<ItemVencimientoConAlerta[]>(ITEMS_KEY, (items) => {
+        const actuales = items ?? [];
+        const yaEstaba = actuales.some((i) => i.id === item.id);
+        return yaEstaba
+          ? actuales.map((i) => (i.id === item.id ? item : i))
+          : [item, ...actuales];
+      });
+    },
   });
 }
 
 export function useActualizarFechaVencimiento() {
   const queryClient = useQueryClient();
   return useMutation({
+    networkMode: "always",
     mutationFn: ({ id, fechaVencimiento }: { id: string; fechaVencimiento: Date }) =>
-      vencimientoService.actualizarFecha(id, fechaVencimiento),
+      ejecutarOEncolar(
+        id,
+        () => vencimientoService.actualizarFecha(id, fechaVencimiento),
+        () =>
+          enqueueOperation("vencimiento.actualizarFecha", {
+            id,
+            fechaVencimiento: fechaVencimiento.toISOString().slice(0, 10),
+          }),
+        null as ItemVencimientoConAlerta | null
+      ),
     onMutate: async ({ id, fechaVencimiento }) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemVencimientoConAlerta[]>(ITEMS_KEY);
       queryClient.setQueryData<ItemVencimientoConAlerta[]>(ITEMS_KEY, (items) =>
-        (items ?? []).map((item) => (item.id === id ? { ...item, fechaVencimiento } : item))
+        (items ?? []).map((item) =>
+          item.id === id
+            ? { ...item, fechaVencimiento, alertaNivel: calcularNivelAlerta(fechaVencimiento) }
+            : item
+        )
       );
       return { previous };
     },
     onError: (_err, _vars, context) => {
       if (context?.previous) queryClient.setQueryData(ITEMS_KEY, context.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
   });
 }
 
 export function useActualizarCantidadVencimiento() {
   const queryClient = useQueryClient();
   return useMutation({
+    networkMode: "always",
     mutationFn: ({ id, cantidad }: { id: string; cantidad: number }) =>
-      vencimientoService.actualizarCantidad(id, cantidad),
+      ejecutarOEncolar(
+        id,
+        () => vencimientoService.actualizarCantidad(id, cantidad),
+        () => enqueueOperation("vencimiento.actualizarCantidad", { id, cantidad }),
+        null as ItemVencimientoConAlerta | null
+      ),
     onMutate: async ({ id, cantidad }) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemVencimientoConAlerta[]>(ITEMS_KEY);
@@ -66,14 +130,20 @@ export function useActualizarCantidadVencimiento() {
     onError: (_err, _vars, context) => {
       if (context?.previous) queryClient.setQueryData(ITEMS_KEY, context.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
   });
 }
 
 export function useEliminarVencimientoItem() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => vencimientoService.eliminarItem(id),
+    networkMode: "always",
+    mutationFn: (id: string) =>
+      ejecutarOEncolar(
+        id,
+        () => vencimientoService.eliminarItem(id),
+        () => enqueueOperation("vencimiento.eliminarItem", { id }),
+        undefined as void
+      ),
     onMutate: async (id) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemVencimientoConAlerta[]>(ITEMS_KEY);
@@ -85,7 +155,6 @@ export function useEliminarVencimientoItem() {
     onError: (_err, _id, context) => {
       if (context?.previous) queryClient.setQueryData(ITEMS_KEY, context.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ITEMS_KEY }),
   });
 }
 
@@ -93,7 +162,14 @@ export function useEliminarVencimientoItem() {
 export function useRetirarVencimientoItem() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => vencimientoService.retirarItem(id),
+    networkMode: "always",
+    mutationFn: (id: string) =>
+      ejecutarOEncolar(
+        id,
+        () => vencimientoService.retirarItem(id),
+        () => enqueueOperation("vencimiento.retirarItem", { id }),
+        undefined as void
+      ),
     onMutate: async (id) => {
       await queryClient.cancelQueries({ queryKey: ITEMS_KEY });
       const previous = queryClient.getQueryData<ItemVencimientoConAlerta[]>(ITEMS_KEY);

--- a/src/lib/outbox/__tests__/outbox.test.ts
+++ b/src/lib/outbox/__tests__/outbox.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const memoria = new Map<string, unknown>();
+
+vi.mock("idb-keyval", () => ({
+  get: vi.fn(async (key: string) => memoria.get(key)),
+  set: vi.fn(async (key: string, val: unknown) => {
+    memoria.set(key, val);
+  }),
+  del: vi.fn(async (key: string) => {
+    memoria.delete(key);
+  }),
+  createStore: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/outbox/executors", () => ({
+  ejecutarOperacion: vi.fn(),
+}));
+
+beforeEach(() => {
+  memoria.clear();
+  vi.clearAllMocks();
+});
+
+describe("enqueueOperation / countPending", () => {
+  it("agrega una operación a la cola y actualiza el contador", async () => {
+    const { enqueueOperation, countPending } = await import("@/lib/outbox/outbox");
+
+    expect(await countPending()).toBe(0);
+    await enqueueOperation("reposicion.actualizarCantidad", { id: "item-1", cantidad: 3 });
+    expect(await countPending()).toBe(1);
+
+    const { useOutboxStore } = await import("@/store/outbox");
+    expect(useOutboxStore.getState().pendingCount).toBe(1);
+  });
+});
+
+describe("processQueue", () => {
+  it("procesa las operaciones en orden y vacía la cola cuando todas resuelven", async () => {
+    const { enqueueOperation, processQueue, countPending } = await import(
+      "@/lib/outbox/outbox"
+    );
+    const { ejecutarOperacion } = await import("@/lib/outbox/executors");
+    vi.mocked(ejecutarOperacion).mockResolvedValue(undefined);
+
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-1" });
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-2" });
+
+    await processQueue();
+
+    expect(await countPending()).toBe(0);
+    expect(ejecutarOperacion).toHaveBeenCalledTimes(2);
+  });
+
+  it("remapea el tempId de una creación offline a las operaciones encoladas después", async () => {
+    const { enqueueOperation, processQueue } = await import("@/lib/outbox/outbox");
+    const { ejecutarOperacion } = await import("@/lib/outbox/executors");
+
+    await enqueueOperation("reposicion.agregarItem", {
+      tempId: "offline:abc",
+      varianteId: "variante-1",
+      cantidad: 1,
+    });
+    await enqueueOperation("reposicion.actualizarCantidad", {
+      id: "offline:abc",
+      cantidad: 3,
+    });
+
+    vi.mocked(ejecutarOperacion).mockImplementation(async (op) => {
+      if (op.type === "reposicion.agregarItem") {
+        return { tempId: op.payload.tempId, realId: "real-1" };
+      }
+      return undefined;
+    });
+
+    await processQueue();
+
+    expect(ejecutarOperacion).toHaveBeenCalledTimes(2);
+    // La segunda llamada debe poder resolver "offline:abc" -> "real-1" via resolveId
+    const resolveIdSegundaLlamada = vi.mocked(ejecutarOperacion).mock.calls[1][1];
+    expect(resolveIdSegundaLlamada("offline:abc")).toBe("real-1");
+  });
+
+  it("corta la corrida y deja la cola intacta ante un error de red", async () => {
+    const { enqueueOperation, processQueue, countPending } = await import(
+      "@/lib/outbox/outbox"
+    );
+    const { ejecutarOperacion } = await import("@/lib/outbox/executors");
+    vi.mocked(ejecutarOperacion).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-1" });
+    await processQueue();
+
+    expect(await countPending()).toBe(1);
+  });
+
+  it("descarta una operación con error de datos (no de red) y sigue con el resto", async () => {
+    const { enqueueOperation, processQueue, countPending } = await import(
+      "@/lib/outbox/outbox"
+    );
+    const { ejecutarOperacion } = await import("@/lib/outbox/executors");
+    vi.mocked(ejecutarOperacion)
+      .mockRejectedValueOnce(new Error("item no existe"))
+      .mockResolvedValueOnce(undefined);
+
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-1" });
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-2" });
+
+    await processQueue();
+
+    expect(await countPending()).toBe(0);
+    expect(ejecutarOperacion).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/outbox/db.ts
+++ b/src/lib/outbox/db.ts
@@ -1,0 +1,10 @@
+import { createStore } from "idb-keyval";
+
+/**
+ * Store de IndexedDB dedicado a la cola offline, separado del cache de
+ * React Query (que vive solo en memoria y no sobrevive a un reload).
+ */
+export const outboxStore =
+  typeof indexedDB !== "undefined"
+    ? createStore("gondolapp-outbox", "operaciones")
+    : undefined;

--- a/src/lib/outbox/executors.ts
+++ b/src/lib/outbox/executors.ts
@@ -1,0 +1,72 @@
+import * as reposicionService from "@/services/reposicion";
+import * as vencimientoService from "@/services/vencimiento";
+import { OutboxOperation } from "./types";
+
+export interface ResultadoEjecucion {
+  /** Presente cuando la operación era una creación offline (tiene tempId). */
+  tempId?: string;
+  /** Id real asignado por Supabase, para remapear operaciones encoladas después. */
+  realId?: string;
+}
+
+/**
+ * Ejecuta una operación de la cola contra Supabase. `resolveId` traduce un
+ * tempId (item creado offline) al id real, si ya se resolvió antes en la
+ * misma corrida de `processQueue`.
+ */
+export async function ejecutarOperacion(
+  op: OutboxOperation,
+  resolveId: (id: string) => string
+): Promise<ResultadoEjecucion | void> {
+  switch (op.type) {
+    case "reposicion.agregarItem": {
+      const item = await reposicionService.agregarItem(
+        op.payload.varianteId,
+        op.payload.cantidad
+      );
+      return { tempId: op.payload.tempId, realId: item.id };
+    }
+    case "reposicion.actualizarCantidad":
+      await reposicionService.actualizarCantidad(
+        resolveId(op.payload.id),
+        op.payload.cantidad
+      );
+      return;
+    case "reposicion.cambiarEstado":
+      await reposicionService.cambiarEstado(
+        resolveId(op.payload.id),
+        op.payload.estado
+      );
+      return;
+    case "reposicion.eliminarItem":
+      await reposicionService.eliminarItem(resolveId(op.payload.id));
+      return;
+    case "vencimiento.agregarItem": {
+      const item = await vencimientoService.agregarItem(
+        op.payload.varianteId,
+        new Date(op.payload.fechaVencimiento),
+        op.payload.cantidad,
+        op.payload.lote
+      );
+      return { tempId: op.payload.tempId, realId: item.id };
+    }
+    case "vencimiento.actualizarFecha":
+      await vencimientoService.actualizarFecha(
+        resolveId(op.payload.id),
+        new Date(op.payload.fechaVencimiento)
+      );
+      return;
+    case "vencimiento.actualizarCantidad":
+      await vencimientoService.actualizarCantidad(
+        resolveId(op.payload.id),
+        op.payload.cantidad
+      );
+      return;
+    case "vencimiento.eliminarItem":
+      await vencimientoService.eliminarItem(resolveId(op.payload.id));
+      return;
+    case "vencimiento.retirarItem":
+      await vencimientoService.retirarItem(resolveId(op.payload.id));
+      return;
+  }
+}

--- a/src/lib/outbox/mutationHelpers.ts
+++ b/src/lib/outbox/mutationHelpers.ts
@@ -1,0 +1,27 @@
+import { isNetworkError, isOnline } from "./outbox";
+import { esTempId } from "./types";
+
+/**
+ * Ejecuta una mutación contra Supabase; si el item es offline (tempId, todavía
+ * no sincronizado) o no hay red, encola la operación en su lugar y devuelve
+ * `valorOffline` sin lanzar error — el `onMutate` optimista del hook ya deja
+ * la UI en el estado correcto, así que no hace falta esperar la red.
+ */
+export async function ejecutarOEncolar<T>(
+  id: string,
+  ejecutar: () => Promise<T>,
+  encolar: () => Promise<void>,
+  valorOffline: T
+): Promise<T> {
+  if (esTempId(id) || !isOnline()) {
+    await encolar();
+    return valorOffline;
+  }
+  try {
+    return await ejecutar();
+  } catch (err) {
+    if (!isNetworkError(err)) throw err;
+    await encolar();
+    return valorOffline;
+  }
+}

--- a/src/lib/outbox/outbox.ts
+++ b/src/lib/outbox/outbox.ts
@@ -1,0 +1,95 @@
+import { del, get, set } from "idb-keyval";
+import { generarUUID } from "@/lib/utils";
+import { useOutboxStore } from "@/store/outbox";
+import { outboxStore } from "./db";
+import { ejecutarOperacion } from "./executors";
+import { OutboxOperation, OutboxOperationType, PayloadOf } from "./types";
+
+const QUEUE_KEY = "queue";
+
+async function readQueue(): Promise<OutboxOperation[]> {
+  return (await get<OutboxOperation[]>(QUEUE_KEY, outboxStore)) ?? [];
+}
+
+async function writeQueue(queue: OutboxOperation[]): Promise<void> {
+  await set(QUEUE_KEY, queue, outboxStore);
+  useOutboxStore.getState().setPendingCount(queue.length);
+}
+
+/** Encola una operación para ejecutarla contra Supabase apenas haya conexión. */
+export async function enqueueOperation<T extends OutboxOperationType>(
+  type: T,
+  payload: PayloadOf<T>
+): Promise<void> {
+  const queue = await readQueue();
+  queue.push({
+    id: generarUUID(),
+    type,
+    payload,
+    createdAt: Date.now(),
+  } as OutboxOperation);
+  await writeQueue(queue);
+}
+
+export async function countPending(): Promise<number> {
+  return (await readQueue()).length;
+}
+
+/** Solo para tests/depuración: vacía la cola sin ejecutar nada. */
+export async function clearQueue(): Promise<void> {
+  await del(QUEUE_KEY, outboxStore);
+  useOutboxStore.getState().setPendingCount(0);
+}
+
+export function isOnline(): boolean {
+  return typeof navigator === "undefined" || navigator.onLine;
+}
+
+export function isNetworkError(err: unknown): boolean {
+  if (!isOnline()) return true;
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error && /fetch|network/i.test(err.message)) return true;
+  return false;
+}
+
+let procesando = false;
+
+/**
+ * Procesa la cola en orden (FIFO). Cuando una operación de creación se
+ * sincroniza, su tempId se resuelve al id real de Supabase y se propaga a
+ * las operaciones siguientes en la misma corrida que referencien ese mismo
+ * item (por ejemplo: crear offline → cambiar cantidad offline, en ese orden).
+ *
+ * Si una operación falla por red, la corrida se corta ahí (la cola queda
+ * intacta) para reintentar más tarde. Si falla por otra razón (dato
+ * inválido, item ya no existe), se descarta esa operación puntual para no
+ * bloquear el resto de la cola.
+ */
+export async function processQueue(): Promise<void> {
+  if (procesando || !isOnline()) return;
+  procesando = true;
+  useOutboxStore.getState().setSyncing(true);
+  try {
+    const idMap = new Map<string, string>();
+    for (;;) {
+      const queue = await readQueue();
+      if (queue.length === 0) break;
+      const [op, ...resto] = queue;
+      const resolveId = (id: string) => idMap.get(id) ?? id;
+      try {
+        const resultado = await ejecutarOperacion(op, resolveId);
+        if (resultado?.tempId && resultado.realId) {
+          idMap.set(resultado.tempId, resultado.realId);
+        }
+        await writeQueue(resto);
+      } catch (err) {
+        if (isNetworkError(err)) break;
+        // Error de datos (no de red): se descarta para no bloquear la cola.
+        await writeQueue(resto);
+      }
+    }
+  } finally {
+    procesando = false;
+    useOutboxStore.getState().setSyncing(false);
+  }
+}

--- a/src/lib/outbox/types.ts
+++ b/src/lib/outbox/types.ts
@@ -1,0 +1,87 @@
+import { generarUUID } from "@/lib/utils";
+import { EstadoReposicion } from "@/types";
+
+/**
+ * Cada operación referencia items por id. Cuando el item fue creado offline,
+ * ese id es un "tempId" (prefijo "offline:") hasta que la creación se
+ * sincronice y se resuelva contra el id real de Supabase.
+ */
+export type OutboxOperation =
+  | {
+      id: string;
+      type: "reposicion.agregarItem";
+      payload: { tempId: string; varianteId: string; cantidad: number };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "reposicion.actualizarCantidad";
+      payload: { id: string; cantidad: number };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "reposicion.cambiarEstado";
+      payload: { id: string; estado: EstadoReposicion };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "reposicion.eliminarItem";
+      payload: { id: string };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "vencimiento.agregarItem";
+      payload: {
+        tempId: string;
+        varianteId: string;
+        fechaVencimiento: string;
+        cantidad?: number;
+        lote?: string;
+      };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "vencimiento.actualizarFecha";
+      payload: { id: string; fechaVencimiento: string };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "vencimiento.actualizarCantidad";
+      payload: { id: string; cantidad: number };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "vencimiento.eliminarItem";
+      payload: { id: string };
+      createdAt: number;
+    }
+  | {
+      id: string;
+      type: "vencimiento.retirarItem";
+      payload: { id: string };
+      createdAt: number;
+    };
+
+export type OutboxOperationType = OutboxOperation["type"];
+
+export type PayloadOf<T extends OutboxOperationType> = Extract<
+  OutboxOperation,
+  { type: T }
+>["payload"];
+
+/** Prefijo que marca un id generado en el cliente mientras el item no existe todavía en Supabase. */
+export const TEMP_ID_PREFIX = "offline:";
+
+export function esTempId(id: string): boolean {
+  return id.startsWith(TEMP_ID_PREFIX);
+}
+
+export function crearTempId(): string {
+  return `${TEMP_ID_PREFIX}${generarUUID()}`;
+}

--- a/src/services/__tests__/reposicion.test.ts
+++ b/src/services/__tests__/reposicion.test.ts
@@ -40,7 +40,7 @@ describe("agregarItem", () => {
     const { agregarItem } = await import("@/services/reposicion");
     fromMock.mockImplementation(
       mockSupabaseFrom(
-        { data: itemRow({ cantidad: 3 }) }, // busca pendiente existente
+        { data: [itemRow({ cantidad: 3 })] }, // busca existente (cualquier estado)
         { data: itemRow({ cantidad: 5 }) } // update con la suma
       )
     );
@@ -50,17 +50,31 @@ describe("agregarItem", () => {
     expect(fromMock).toHaveBeenCalledTimes(2);
   });
 
-  it("crea un item nuevo si no hay uno pendiente para esa variante", async () => {
+  it("crea un item nuevo si no hay ninguno para esa variante", async () => {
     const { agregarItem } = await import("@/services/reposicion");
     fromMock.mockImplementation(
       mockSupabaseFrom(
-        { data: null }, // no hay pendiente
+        { data: [] }, // no hay ninguno
         { data: itemRow({ id: "item-nuevo", cantidad: 4 }) } // insert
       )
     );
 
     const item = await agregarItem("variante-1", 4);
     expect(item.id).toBe("item-nuevo");
+    expect(item.estado).toBe("pendiente");
+  });
+
+  it("reabre y fusiona cantidad contra un item ya repuesto/sin_stock de la misma variante", async () => {
+    const { agregarItem } = await import("@/services/reposicion");
+    fromMock.mockImplementation(
+      mockSupabaseFrom(
+        { data: [itemRow({ cantidad: 2, estado: "sin_stock" })] }, // existente, no pendiente
+        { data: itemRow({ cantidad: 3, estado: "pendiente" }) } // update: suma y reabre a pendiente
+      )
+    );
+
+    const item = await agregarItem("variante-1", 1);
+    expect(item.cantidad).toBe(3);
     expect(item.estado).toBe("pendiente");
   });
 });

--- a/src/services/reposicion.ts
+++ b/src/services/reposicion.ts
@@ -92,23 +92,28 @@ export async function listarItems(): Promise<ItemReposicion[]> {
   return (data ?? []).map((row) => mapItem(row as ItemReposicionRow));
 }
 
-/** Agrega cantidad a un item pendiente existente de la misma variante, o crea uno nuevo. */
+/**
+ * Agrega cantidad a un item existente de la misma variante (en cualquier
+ * estado, no solo pendiente: reescanear algo ya repuesto/sin_stock lo
+ * reabre en vez de crear una fila duplicada), o crea uno nuevo si no existe.
+ */
 export async function agregarItem(
   varianteId: string,
   cantidad: number
 ): Promise<ItemReposicion> {
-  const { data: existente, error: buscarError } = await supabase
+  const { data: existentes, error: buscarError } = await supabase
     .from("items_reposicion")
     .select("*")
     .eq("variante_id", varianteId)
-    .eq("estado", "pendiente")
-    .maybeSingle();
+    .order("agregado_at", { ascending: false })
+    .limit(1);
   if (buscarError) throw buscarError;
+  const existente = existentes?.[0];
 
   if (existente) {
     const { data, error } = await supabase
       .from("items_reposicion")
-      .update({ cantidad: existente.cantidad + cantidad })
+      .update({ cantidad: existente.cantidad + cantidad, estado: "pendiente" })
       .eq("id", existente.id)
       .select()
       .single();

--- a/src/store/outbox.ts
+++ b/src/store/outbox.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+/** Estado de UI (no de negocio) para reflejar la cola offline: cuántas
+ * operaciones esperan sincronizarse y si hay una corrida de sync en curso. */
+interface OutboxState {
+  pendingCount: number;
+  isSyncing: boolean;
+  setPendingCount: (n: number) => void;
+  setSyncing: (v: boolean) => void;
+}
+
+export const useOutboxStore = create<OutboxState>((set) => ({
+  pendingCount: 0,
+  isSyncing: false,
+  setPendingCount: (n) => set({ pendingCount: n }),
+  setSyncing: (v) => set({ isSyncing: v }),
+}));


### PR DESCRIPTION
Las mutaciones de reposición y vencimiento ahora encolan localmente
(IndexedDB) cuando no hay red y se sincronizan solas al reconectar, en
vez de fallar con un toast y perder el cambio. Se agrega un indicador
de cambios pendientes de sincronizar en el header.

De paso, se corrige agregarItem en reposición para que el merge por
variante también reabra items ya repuestos/sin_stock en vez de crear
una fila duplicada (necesario para que el executor offline reutilice
la misma lógica).