### PR TITLE
Corrige el crash al recargar: el catálogo persistido perdía su Map

### DIFF
--- a/src/app/QueryProvider.tsx
+++ b/src/app/QueryProvider.tsx
@@ -31,7 +31,9 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       persistOptions={{
         persister: queryPersister,
         maxAge: MAX_AGE_CACHE_MS,
-        buster: "v1",
+        // v2: el catálogo pasó de Map (serializaba como {}) a objeto plano;
+        // el bump descarta caches v1 corruptos que crasheaban al rehidratar.
+        buster: "v2",
         dehydrateOptions: {
           shouldDehydrateQuery: (query) =>
             query.state.status === "success" &&

--- a/src/components/BarcodeScanner.tsx
+++ b/src/components/BarcodeScanner.tsx
@@ -37,7 +37,6 @@ export default function BarcodeScanner({
   const [isClosing, setIsClosing] = useState(false);
   const [showManualInput, setShowManualInput] = useState(false);
   const [manualCode, setManualCode] = useState("");
-  const [lastScannedCode, setLastScannedCode] = useState<string | null>(null);
 
   const scannerRef = useRef<Html5Qrcode | null>(null);
   const readerElementRef = useRef<HTMLDivElement>(null);
@@ -54,6 +53,12 @@ export default function BarcodeScanner({
   // detener, para no dejar la cámara abierta sin referencia (bug que
   // obligaba a recargar la página para poder volver a abrirla).
   const startingPromiseRef = useRef<Promise<void> | null>(null);
+  // Ref (no state): html5-qrcode invoca el onScanSuccess con el que se
+  // inició la cámara, así que un state quedaría congelado en su closure y
+  // el dedupe nunca filtraría — cada frame decodificado (30 fps) dispararía
+  // un onScan del mismo código.
+  const lastScannedCodeRef = useRef<string | null>(null);
+  const clearScannedCodeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Tiempo para limpiar el código escaneado y permitir re-escanear el mismo código
   const SCAN_CODE_CLEAR_DELAY = 2000;
@@ -110,7 +115,7 @@ export default function BarcodeScanner({
     }
     scannerRef.current = null;
     setIsScanning(false);
-    setLastScannedCode(null);
+    lastScannedCodeRef.current = null;
     isStoppingRef.current = false;
   }, []);
 
@@ -161,8 +166,8 @@ export default function BarcodeScanner({
 
       const onScanSuccess = (decodedText: string) => {
         if (pausedRef.current) return;
-        if (decodedText !== lastScannedCode && !isClosing) {
-          setLastScannedCode(decodedText);
+        if (decodedText !== lastScannedCodeRef.current && !isClosing) {
+          lastScannedCodeRef.current = decodedText;
           onScan(decodedText);
 
           if ("vibrate" in navigator) {
@@ -170,8 +175,11 @@ export default function BarcodeScanner({
           }
 
           // Limpiar el código escaneado después de un tiempo para permitir re-escaneo
-          setTimeout(() => {
-            setLastScannedCode(null);
+          if (clearScannedCodeTimerRef.current) {
+            clearTimeout(clearScannedCodeTimerRef.current);
+          }
+          clearScannedCodeTimerRef.current = setTimeout(() => {
+            lastScannedCodeRef.current = null;
           }, SCAN_CODE_CLEAR_DELAY);
         }
       };
@@ -257,7 +265,6 @@ export default function BarcodeScanner({
     isClosing,
     showManualInput,
     scannerElementId,
-    lastScannedCode,
     stopScanning,
     onScan,
     onClose,
@@ -313,7 +320,7 @@ export default function BarcodeScanner({
     await stopScanning();
 
     setIsScanning(false);
-    setLastScannedCode(null);
+    lastScannedCodeRef.current = null;
     setError(null);
     setIsLoading(false);
 
@@ -332,7 +339,7 @@ export default function BarcodeScanner({
       setIsScanning(false);
       setIsLoading(false);
       setError(null);
-      setLastScannedCode(null);
+      lastScannedCodeRef.current = null;
       setShowManualInput(false);
       setManualCode("");
       isStoppingRef.current = false;
@@ -463,9 +470,6 @@ export default function BarcodeScanner({
               </div>
             )}
 
-            {/* Overlay flotante inyectado por el padre (ej. QuickAdjustCard) */}
-            {overlay}
-
             {/* Instrucción mínima cuando está escaneando (sin overlay del padre) */}
             {isScanning && !isLoading && !overlay && (
               <div className="absolute bottom-0 left-0 right-0 p-4 flex justify-center">
@@ -479,6 +483,11 @@ export default function BarcodeScanner({
           </div>
         )}
       </div>
+
+      {/* Overlay flotante inyectado por el padre (ej. QuickAdjustCard).
+          Fuera de la rama de cámara: también debe verse tras agregar un
+          producto por entrada manual. */}
+      {overlay}
 
       {/* Error Message */}
       {error && (

--- a/src/components/reposicion/ReposicionList.tsx
+++ b/src/components/reposicion/ReposicionList.tsx
@@ -97,7 +97,7 @@ export function ReposicionList() {
     if (!productosPorVariante) return [];
     return items
       .map((item) => {
-        const producto = productosPorVariante.get(item.varianteId);
+        const producto = productosPorVariante[item.varianteId];
         if (!producto) return null;
         return { item, variante: producto.variante, base: producto.base };
       })

--- a/src/components/scanner/QuickAdjustCard.tsx
+++ b/src/components/scanner/QuickAdjustCard.tsx
@@ -53,7 +53,9 @@ export function QuickAdjustCard({
           animate={{ opacity: 1, y: 0, scale: 1, x: "-50%" }}
           exit={{ opacity: 0, y: 24, scale: 0.96, x: "-50%" }}
           transition={springSnappy}
-          className="fixed left-1/2 z-30 w-[calc(100%-2rem)] max-w-sm"
+          // z > 50: al montarse en document.body compite con el contenedor
+          // fullscreen del escáner (fixed z-50), no con sus hijos.
+          className="fixed left-1/2 z-[60] w-[calc(100%-2rem)] max-w-sm"
           style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + 96px)" }}
         >
           <div className="glass rounded-card shadow-float overflow-hidden">

--- a/src/components/vencimiento/VencimientoList.tsx
+++ b/src/components/vencimiento/VencimientoList.tsx
@@ -93,7 +93,7 @@ export function VencimientoList() {
     if (!productosPorVariante) return [];
     return items
       .map((item) => {
-        const producto = productosPorVariante.get(item.varianteId);
+        const producto = productosPorVariante[item.varianteId];
         if (!producto) return null;
         return { item, variante: producto.variante };
       })

--- a/src/services/__tests__/catalogo.test.ts
+++ b/src/services/__tests__/catalogo.test.ts
@@ -178,23 +178,34 @@ describe("crearProductoManual", () => {
 });
 
 describe("obtenerProductosPorVarianteIds", () => {
-  it("devuelve un mapa vacío sin consultar la base si no hay ids", async () => {
+  it("devuelve un objeto vacío sin consultar la base si no hay ids", async () => {
     const { obtenerProductosPorVarianteIds } = await import("@/services/catalogo");
     const resultado = await obtenerProductosPorVarianteIds([]);
-    expect(resultado.size).toBe(0);
+    expect(Object.keys(resultado)).toHaveLength(0);
     expect(fromMock).not.toHaveBeenCalled();
   });
 
-  it("arma el mapa varianteId -> {base, variante} en un solo round-trip", async () => {
+  it("arma el índice varianteId -> {base, variante} en un solo round-trip", async () => {
     const { obtenerProductosPorVarianteIds } = await import("@/services/catalogo");
     fromMock.mockImplementation(
       mockSupabaseFrom({ data: [{ ...varianteRow, producto_bases: baseRow }] })
     );
 
     const resultado = await obtenerProductosPorVarianteIds(["variante-1", "variante-1"]);
-    expect(resultado.size).toBe(1);
-    expect(resultado.get("variante-1")?.base.nombre).toBe("Leche");
+    expect(Object.keys(resultado)).toHaveLength(1);
+    expect(resultado["variante-1"]?.base.nombre).toBe("Leche");
     expect(fromMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sobrevive el round-trip JSON del persister (regresión: Map serializaba como {})", async () => {
+    const { obtenerProductosPorVarianteIds } = await import("@/services/catalogo");
+    fromMock.mockImplementation(
+      mockSupabaseFrom({ data: [{ ...varianteRow, producto_bases: baseRow }] })
+    );
+
+    const resultado = await obtenerProductosPorVarianteIds(["variante-1"]);
+    const restaurado = JSON.parse(JSON.stringify(resultado));
+    expect(restaurado["variante-1"]?.base.nombre).toBe("Leche");
   });
 });
 

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -250,12 +250,19 @@ export async function crearProductoManual(
   };
 }
 
-/** Trae base+variante para un lote de varianteId de una sola vez (evita N+1 en las listas). */
+/**
+ * Trae base+variante para un lote de varianteId de una sola vez (evita N+1 en las listas).
+ *
+ * Devuelve un objeto plano (no un Map): esta query se persiste en IndexedDB
+ * vía JSON.stringify (ver queryPersister.ts) y un Map serializa como `{}`,
+ * lo que rompía la app al rehidratar (`.get is not a function`).
+ */
 export async function obtenerProductosPorVarianteIds(
   varianteIds: string[]
-): Promise<Map<string, ProductoCompleto>> {
+): Promise<Record<string, ProductoCompleto>> {
   const idsUnicos = Array.from(new Set(varianteIds));
-  if (idsUnicos.length === 0) return new Map();
+  const resultado: Record<string, ProductoCompleto> = {};
+  if (idsUnicos.length === 0) return resultado;
 
   const { data, error } = await supabase
     .from("producto_variantes")
@@ -263,11 +270,10 @@ export async function obtenerProductosPorVarianteIds(
     .in("id", idsUnicos);
   if (error) throw error;
 
-  const resultado = new Map<string, ProductoCompleto>();
   for (const row of (data ?? []) as ProductoVarianteConBaseRow[]) {
     const producto = mapProductoCompleto(row);
     if (!producto) continue;
-    resultado.set(row.id, producto);
+    resultado[row.id] = producto;
   }
   return resultado;
 }


### PR DESCRIPTION
La query ["catalogo", "por-variante-ids"] devolvía un Map, pero el
persister de React Query la serializa con JSON.stringify, que convierte
un Map en {}. En la siguiente visita el cache restaurado llegaba a las
listas como objeto plano y productosPorVariante.get(...) tiraba
"TypeError: .get is not a function" durante el render, mostrando
"Application error: a client-side exception has occurred" en producción
para todo usuario con cache persistido.

- obtenerProductosPorVarianteIds ahora devuelve un Record plano que
  sobrevive el round-trip JSON del persister.
- Las listas indexan por clave en vez de .get().
- Bump del buster v1 -> v2 para descartar los caches ya corruptos que
  seguían crasheando la app en cada arranque.
- Test de regresión: el resultado del catálogo sobrevive
  JSON.parse(JSON.stringify(...)).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BXCMT5ikhYn3UP5F7k9Kmv