### PR TITLE
Atributos flexibles por variante: jsonb en vez de tipo/sabor/tamano

### DIFF
--- a/src/app/QueryProvider.tsx
+++ b/src/app/QueryProvider.tsx
@@ -31,9 +31,11 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       persistOptions={{
         persister: queryPersister,
         maxAge: MAX_AGE_CACHE_MS,
-        // v2: el catálogo pasó de Map (serializaba como {}) a objeto plano;
-        // el bump descarta caches v1 corruptos que crasheaban al rehidratar.
-        buster: "v2",
+        // v3: ProductoVariante pasó de tipo/tamano/sabor a atributos jsonb;
+        // el bump descarta caches con el shape viejo (la rehidratación no
+        // pasa por el mapper, así que el `?? {}` defensivo no alcanza).
+        // (v2 había descartado los Map serializados como {} de v1.)
+        buster: "v3",
         dehydrateOptions: {
           shouldDehydrateQuery: (query) =>
             query.state.status === "success" &&

--- a/src/app/api/productos/crear-manual/route.ts
+++ b/src/app/api/productos/crear-manual/route.ts
@@ -1,6 +1,43 @@
-import { crearProductoManual, obtenerMarcasYCategorias } from "@/services/catalogo";
-import { CrearProductoDTO } from "@/types";
+import {
+  crearProductoManual,
+  obtenerDefinicionesAtributos,
+  obtenerMarcasYCategorias,
+} from "@/services/catalogo";
+import { AtributosVariante, CategoriaAtributo, CrearProductoDTO } from "@/types";
 import { NextRequest, NextResponse } from "next/server";
+
+/** El body viene de la red: no confiar en el shape de CrearProductoDTO. */
+function esObjetoPlanoDeStrings(valor: unknown): valor is AtributosVariante {
+  return (
+    typeof valor === "object" &&
+    valor !== null &&
+    !Array.isArray(valor) &&
+    Object.values(valor).every((v) => typeof v === "string")
+  );
+}
+
+/**
+ * Normaliza whitespace y, si el valor matchea case-insensitive una
+ * sugerencia de la definición, lo sustituye por la forma canónica. Es la
+ * única defensa contra "Vainilla"/"vainilla"/"VAINILLA" conviviendo en el
+ * jsonb (el schema no valida valores): el datalist del formulario empuja
+ * hacia el canon y acá se consolida lo que llegue tipeado distinto.
+ */
+function canonicalizarAtributos(
+  atributos: AtributosVariante,
+  defs: CategoriaAtributo[]
+): AtributosVariante {
+  const sugerenciasPorClave = new Map(defs.map((d) => [d.clave, d.sugerencias ?? []]));
+  return Object.fromEntries(
+    Object.entries(atributos).map(([clave, valor]) => {
+      const normalizado = valor.replace(/\s+/g, " ").trim();
+      const canonico = sugerenciasPorClave
+        .get(clave)
+        ?.find((s) => s.toLowerCase() === normalizado.toLowerCase());
+      return [clave, canonico ?? normalizado];
+    })
+  );
+}
 
 /**
  * POST /api/productos/crear-manual
@@ -18,7 +55,31 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const producto = await crearProductoManual(body);
+    const atributosCrudos = body.variante?.atributos ?? {};
+    if (!esObjetoPlanoDeStrings(atributosCrudos)) {
+      return NextResponse.json(
+        { success: false, error: "atributos debe ser un objeto plano de strings" },
+        { status: 400 }
+      );
+    }
+
+    // Si las definiciones no se pueden leer, se crea igual sin canonicalizar:
+    // perder el alta por un fallo del lookup sería peor que un valor sin canon.
+    let atributos = atributosCrudos;
+    try {
+      const defs = await obtenerDefinicionesAtributos();
+      const categoria = body.productoBase.categoria?.trim();
+      const defsAplicables =
+        (categoria && defs.porCategoria[categoria]) || defs.default;
+      atributos = canonicalizarAtributos(atributosCrudos, defsAplicables);
+    } catch {
+      // sin canonicalización
+    }
+
+    const producto = await crearProductoManual({
+      ...body,
+      variante: { ...body.variante, atributos },
+    });
 
     return NextResponse.json({
       success: true,
@@ -32,7 +93,9 @@ export async function POST(request: NextRequest) {
         variante: {
           id: producto.variante.id,
           nombreCompleto: producto.variante.nombreCompleto,
-          tamano: producto.variante.tamano,
+          atributos: producto.variante.atributos,
+          // Derivado para consumidores que siguen esperando el campo plano.
+          tamano: producto.variante.atributos["tamano"],
         },
       },
     });
@@ -46,17 +109,29 @@ export async function POST(request: NextRequest) {
 /**
  * GET /api/productos/crear-manual
  *
- * Devuelve listas de marcas y categorías existentes para autocompletado
+ * Devuelve marcas y categorías existentes para autocompletado, más las
+ * definiciones de atributos que arman el formulario dinámico del alta.
  */
 export async function GET() {
   try {
-    const { marcas, categorias } = await obtenerMarcasYCategorias();
-    return NextResponse.json({ success: true, marcas, categorias });
+    const [{ marcas, categorias }, defs] = await Promise.all([
+      obtenerMarcasYCategorias(),
+      obtenerDefinicionesAtributos(),
+    ]);
+    return NextResponse.json({
+      success: true,
+      marcas,
+      categorias,
+      atributosDefault: defs.default,
+      atributosPorCategoria: defs.porCategoria,
+    });
   } catch {
     return NextResponse.json({
       success: true,
       marcas: [],
       categorias: [],
+      atributosDefault: [],
+      atributosPorCategoria: {},
       warning: "Catálogo no disponible. Autocompletado deshabilitado.",
     });
   }

--- a/src/components/reposicion/ReposicionCard.tsx
+++ b/src/components/reposicion/ReposicionCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useHaptics } from "@/hooks/useHaptics";
+import { ordenarClavesAtributos } from "@/lib/utils";
 import {
   useActualizarCantidadReposicion,
   useCambiarEstadoMasivo,
@@ -175,11 +176,13 @@ export function ReposicionCard({
             <div className="divide-y divide-border">
               {variantes.map(({ item, variante }) => {
                 // El header de la card ya muestra productoBase.nombre, así que acá
-                // se arma solo la parte de variante (tipo+sabor+tamaño) para no
+                // se arma solo la parte de variante (sus atributos) para no
                 // repetir el nombre base que nombreCompleto ya incluye.
                 const descriptorVariante =
-                  [variante.tipo, variante.sabor, variante.tamano].filter(Boolean).join(" ") ||
-                  variante.nombreCompleto;
+                  ordenarClavesAtributos(variante.atributos)
+                    .map((clave) => variante.atributos[clave])
+                    .filter(Boolean)
+                    .join(" ") || variante.nombreCompleto;
                 const seleccionado = estaSeleccionado?.(item.id) ?? false;
                 return (
                 <div

--- a/src/components/reposicion/__tests__/ReposicionCard.test.tsx
+++ b/src/components/reposicion/__tests__/ReposicionCard.test.tsx
@@ -43,7 +43,7 @@ function variante(id: string, estado: ItemReposicion["estado"] = "pendiente") {
     productoBaseId: BASE.id,
     codigoBarras: `77900000${id}`,
     nombreCompleto: `Leche Entera ${id}L`,
-    tamano: `${id}L`,
+    atributos: { tamano: `${id}L` },
     createdAt: new Date("2026-01-01T00:00:00Z"),
   };
   return { item, variante: varianteProducto };

--- a/src/components/scanner/ManualProductSheet.tsx
+++ b/src/components/scanner/ManualProductSheet.tsx
@@ -3,7 +3,7 @@
 import { BottomSheet } from "@/components/ui/BottomSheet";
 import { useMarcasCategorias } from "@/hooks/useMarcasCategorias";
 import { ProductoEscaneado } from "@/hooks/useScanProduct";
-import { CrearProductoDTO } from "@/types";
+import { CategoriaAtributo, CrearProductoDTO } from "@/types";
 import { ChevronDown } from "lucide-react";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
@@ -15,6 +15,20 @@ export interface ManualProductSheetProps {
   onClose: () => void;
 }
 
+// Último fallback cuando el GET de definiciones falló (offline) y no hay
+// nada cacheado: replica el seed global de la migración 0008.
+const DEFS_FALLBACK: CategoriaAtributo[] = [
+  { clave: "tipo", etiqueta: "Tipo", orden: 0 },
+  { clave: "sabor", etiqueta: "Sabor", orden: 1 },
+  { clave: "tamano", etiqueta: "Tamaño", orden: 2 },
+];
+
+const PLACEHOLDER_EJEMPLOS: Record<string, string> = {
+  tipo: "Tipo (ej: Sin Lactosa)",
+  sabor: "Sabor (opcional)",
+  tamano: "Tamaño (ej: 1L)",
+};
+
 /** Formulario de alta rápida para EAN desconocido: sólo nombre + marca son obligatorios. */
 export function ManualProductSheet({
   ean,
@@ -25,25 +39,32 @@ export function ManualProductSheet({
   const [nombre, setNombre] = useState("");
   const [marca, setMarca] = useState("");
   const [categoria, setCategoria] = useState("");
-  const [tipo, setTipo] = useState("");
-  const [tamano, setTamano] = useState("");
-  const [sabor, setSabor] = useState("");
+  const [atributos, setAtributos] = useState<Record<string, string>>({});
   const [detallesAbiertos, setDetallesAbiertos] = useState(false);
   const [enviando, setEnviando] = useState(false);
 
   const { data } = useMarcasCategorias(isOpen);
+
+  // Inputs a mostrar: definición de la categoría si tiene, si no el default
+  // del server, si no el hardcode local. Cambiar de categoría cambia los
+  // inputs pero no borra lo tipeado (se filtra recién al enviar).
+  const defsCategoria = data?.atributosPorCategoria?.[categoria.trim()];
+  const defs =
+    defsCategoria ??
+    (data?.atributosDefault?.length ? data.atributosDefault : DEFS_FALLBACK);
 
   useEffect(() => {
     if (!isOpen) {
       setNombre("");
       setMarca("");
       setCategoria("");
-      setTipo("");
-      setTamano("");
-      setSabor("");
+      setAtributos({});
       setDetallesAbiertos(false);
     }
   }, [isOpen]);
+
+  const setAtributo = (clave: string, valor: string) =>
+    setAtributos((prev) => ({ ...prev, [clave]: valor }));
 
   const handleSubmit = async () => {
     if (!nombre.trim() || !marca.trim()) {
@@ -53,6 +74,14 @@ export function ManualProductSheet({
 
     setEnviando(true);
     try {
+      // Solo las claves visibles: si el usuario tipeó un sabor y después
+      // cambió a una categoría sin sabor, ese valor huérfano no viaja.
+      const atributosVisibles = Object.fromEntries(
+        defs
+          .map((def) => [def.clave, (atributos[def.clave] ?? "").trim()])
+          .filter(([, valor]) => valor)
+      );
+
       const dto: CrearProductoDTO = {
         ean,
         productoBase: {
@@ -61,9 +90,7 @@ export function ManualProductSheet({
           categoria: categoria.trim() || undefined,
         },
         variante: {
-          tipo: tipo.trim() || undefined,
-          tamano: tamano.trim() || undefined,
-          sabor: sabor.trim() || undefined,
+          atributos: atributosVisibles,
         },
       };
 
@@ -133,7 +160,7 @@ export function ManualProductSheet({
           onClick={() => setDetallesAbiertos((v) => !v)}
           className="w-full flex items-center justify-between text-subhead font-semibold text-fg-secondary py-1"
         >
-          Detalles (categoría, tipo, tamaño, sabor)
+          Detalles (categoría y variante)
           <ChevronDown
             size={18}
             className={`transition-transform ${detallesAbiertos ? "rotate-180" : ""}`}
@@ -155,27 +182,25 @@ export function ManualProductSheet({
                 <option key={c} value={c} />
               ))}
             </datalist>
-            <input
-              type="text"
-              value={tipo}
-              onChange={(e) => setTipo(e.target.value)}
-              placeholder="Tipo (ej: Sin Lactosa)"
-              className="w-full h-12 px-4 rounded-field bg-surface-2 text-body text-fg focus:outline-none focus:ring-2 focus:ring-accent/40"
-            />
-            <input
-              type="text"
-              value={tamano}
-              onChange={(e) => setTamano(e.target.value)}
-              placeholder="Tamaño (ej: 1L)"
-              className="w-full h-12 px-4 rounded-field bg-surface-2 text-body text-fg focus:outline-none focus:ring-2 focus:ring-accent/40"
-            />
-            <input
-              type="text"
-              value={sabor}
-              onChange={(e) => setSabor(e.target.value)}
-              placeholder="Sabor (opcional)"
-              className="w-full h-12 px-4 rounded-field bg-surface-2 text-body text-fg focus:outline-none focus:ring-2 focus:ring-accent/40"
-            />
+            {defs.map((def) => (
+              <div key={def.clave}>
+                <input
+                  type="text"
+                  list={def.sugerencias?.length ? `manual-atributo-${def.clave}` : undefined}
+                  value={atributos[def.clave] ?? ""}
+                  onChange={(e) => setAtributo(def.clave, e.target.value)}
+                  placeholder={PLACEHOLDER_EJEMPLOS[def.clave] ?? def.etiqueta}
+                  className="w-full h-12 px-4 rounded-field bg-surface-2 text-body text-fg focus:outline-none focus:ring-2 focus:ring-accent/40"
+                />
+                {def.sugerencias?.length ? (
+                  <datalist id={`manual-atributo-${def.clave}`}>
+                    {def.sugerencias.map((s) => (
+                      <option key={s} value={s} />
+                    ))}
+                  </datalist>
+                ) : null}
+              </div>
+            ))}
           </div>
         )}
 

--- a/src/components/search/ProductSearchSheet.tsx
+++ b/src/components/search/ProductSearchSheet.tsx
@@ -44,7 +44,7 @@ function aSearchItem(producto: ProductoCompleto): SearchItem {
     varianteId: producto.variante.id,
     nombre: producto.variante.nombreCompleto,
     marca: producto.base.marca,
-    tamano: producto.variante.tamano,
+    tamano: producto.variante.atributos["tamano"],
   };
 }
 

--- a/src/hooks/__tests__/useScanProduct.test.tsx
+++ b/src/hooks/__tests__/useScanProduct.test.tsx
@@ -21,7 +21,7 @@ const PRODUCTO: ProductoCompleto = {
     productoBaseId: "base-1",
     codigoBarras: "7790000000001",
     nombreCompleto: "Leche Entera 1L",
-    tamano: "1L",
+    atributos: { tamano: "1L" },
     createdAt: new Date(),
   },
 };

--- a/src/hooks/useMarcasCategorias.ts
+++ b/src/hooks/useMarcasCategorias.ts
@@ -1,10 +1,13 @@
 "use client";
 
+import { CategoriaAtributo } from "@/types";
 import { useQuery } from "@tanstack/react-query";
 
 export interface MarcasCategorias {
   marcas: string[];
   categorias: string[];
+  atributosDefault: CategoriaAtributo[];
+  atributosPorCategoria: Record<string, CategoriaAtributo[]>;
 }
 
 export const MARCAS_CATEGORIAS_KEY = ["catalogo", "marcas-categorias"] as const;
@@ -12,7 +15,12 @@ export const MARCAS_CATEGORIAS_KEY = ["catalogo", "marcas-categorias"] as const;
 export async function fetchMarcasCategorias(): Promise<MarcasCategorias> {
   const res = await fetch("/api/productos/crear-manual");
   const data = await res.json();
-  return { marcas: data.marcas ?? [], categorias: data.categorias ?? [] };
+  return {
+    marcas: data.marcas ?? [],
+    categorias: data.categorias ?? [],
+    atributosDefault: data.atributosDefault ?? [],
+    atributosPorCategoria: data.atributosPorCategoria ?? {},
+  };
 }
 
 /** Marcas/categorías existentes, para el autocompletado del alta manual. */

--- a/src/hooks/useScanProduct.ts
+++ b/src/hooks/useScanProduct.ts
@@ -55,7 +55,7 @@ export function useScanProduct() {
           variante: {
             id: resultado.variante.id,
             nombreCompleto: resultado.variante.nombreCompleto,
-            tamano: resultado.variante.tamano,
+            tamano: resultado.variante.atributos["tamano"],
           },
         };
         queryClient.setQueryData(eanQueryKey(barcode), producto, {

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   construirNombreCompleto,
   formatearFecha,
   generarUUID,
+  ordenarClavesAtributos,
 } from "@/lib/utils";
 
 describe("construirNombreCompleto", () => {
@@ -18,12 +19,46 @@ describe("construirNombreCompleto", () => {
     expect(construirNombreCompleto("Leche", { tamano: "1L" })).toBe("Leche 1L");
   });
 
-  it("siempre incluye el nombre de la base aunque no haya variante", () => {
+  it("siempre incluye el nombre de la base aunque no haya atributos", () => {
     expect(construirNombreCompleto("Yerba", {})).toBe("Yerba");
   });
 
   it("ignora campos vacíos o solo espacios", () => {
     expect(construirNombreCompleto("Yerba", { tipo: "  ", tamano: "1kg" })).toBe("Yerba 1kg");
+  });
+
+  it("pone claves desconocidas al final, en orden alfabético", () => {
+    expect(
+      construirNombreCompleto("Destornillador", {
+        medida: "PH2",
+        tamano: "150mm",
+        material: "Acero",
+      })
+    ).toBe("Destornillador 150mm Acero PH2");
+  });
+
+  it("respeta un orden de claves custom (definición por categoría)", () => {
+    expect(
+      construirNombreCompleto(
+        "Destornillador",
+        { medida: "PH2", material: "Acero" },
+        ["medida", "material"]
+      )
+    ).toBe("Destornillador PH2 Acero");
+  });
+});
+
+describe("ordenarClavesAtributos", () => {
+  it("ordena las claves conocidas según el orden default", () => {
+    expect(
+      ordenarClavesAtributos({ tamano: "1L", tipo: "Entera", sabor: "Vainilla" })
+    ).toEqual(["tipo", "sabor", "tamano"]);
+  });
+
+  it("agrega las desconocidas al final en orden alfabético", () => {
+    expect(
+      ordenarClavesAtributos({ zeta: "z", tamano: "1L", alfa: "a" })
+    ).toEqual(["tamano", "alfa", "zeta"]);
   });
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,14 +1,41 @@
 import { AlertaNivel } from "@/types";
 
+// Orden de armado cuando la categoría no tiene definición propia en
+// categoria_atributos. Debe coincidir con el seed global de la migración 0008.
+export const ORDEN_ATRIBUTOS_DEFAULT = ["tipo", "sabor", "tamano"] as const;
+
 /**
- * Arma el nombre completo mostrado en pantalla para una variante: siempre
- * nombre de la base + tipo (si existe) + sabor + tamaño, en ese orden.
+ * Ordena las claves de un objeto de atributos: primero las conocidas en el
+ * orden dado, después las desconocidas en orden alfabético. Espeja el
+ * criterio de armar_nombre_completo() en BD para que el display client-side
+ * coincida con el nombre_completo derivado por el trigger.
+ */
+export function ordenarClavesAtributos(
+  atributos: Record<string, string | null | undefined>,
+  orden: readonly string[] = ORDEN_ATRIBUTOS_DEFAULT
+): string[] {
+  const conocidas = orden.filter((clave) => clave in atributos);
+  const desconocidas = Object.keys(atributos)
+    .filter((clave) => !orden.includes(clave))
+    .sort();
+  return [...conocidas, ...desconocidas];
+}
+
+/**
+ * Arma el nombre completo mostrado en pantalla para una variante: nombre de
+ * la base + valores de atributos en el orden de la categoría. Solo para
+ * display/optimistic UI: el nombre_completo persistido lo deriva el trigger
+ * de BD (migración 0008), nunca el cliente.
  */
 export function construirNombreCompleto(
   nombreBase: string,
-  variante: { tipo?: string | null; sabor?: string | null; tamano?: string | null }
+  atributos: Record<string, string | null | undefined>,
+  orden: readonly string[] = ORDEN_ATRIBUTOS_DEFAULT
 ): string {
-  return [nombreBase, variante.tipo, variante.sabor, variante.tamano]
+  return [
+    nombreBase,
+    ...ordenarClavesAtributos(atributos, orden).map((clave) => atributos[clave]),
+  ]
     .filter((parte): parte is string => Boolean(parte && parte.trim()))
     .join(" ");
 }

--- a/src/services/__tests__/catalogo.test.ts
+++ b/src/services/__tests__/catalogo.test.ts
@@ -12,9 +12,7 @@ const varianteRow = {
   producto_base_id: "base-1",
   codigo_barras: "7791234567890",
   nombre_completo: "Leche Entera 1L",
-  tipo: "Entera",
-  tamano: "1L",
-  sabor: null,
+  atributos: { tipo: "Entera", tamano: "1L" },
   imagen: null,
   created_at: "2026-01-01T00:00:00Z",
 };
@@ -70,7 +68,7 @@ describe("crearProductoManual", () => {
   const dto = {
     ean: "7799999999999",
     productoBase: { nombre: "Yerba", marca: "Playadito", categoria: "Almacén" },
-    variante: { tamano: "1kg", tipo: "Con Palo" },
+    variante: { atributos: { tamano: "1kg", tipo: "Con Palo" } },
   };
 
   it("rechaza si el código de barras ya existe", async () => {
@@ -90,10 +88,8 @@ describe("crearProductoManual", () => {
       id: "variante-nueva",
       producto_base_id: "base-1",
       codigo_barras: dto.ean,
-      nombre_completo: "Con Palo 1kg",
-      tipo: "Con Palo",
-      tamano: "1kg",
-      sabor: null,
+      nombre_completo: "Yerba Con Palo 1kg",
+      atributos: { tipo: "Con Palo", tamano: "1kg" },
       imagen: null,
       created_at: "2026-01-01T00:00:00Z",
     };
@@ -111,12 +107,12 @@ describe("crearProductoManual", () => {
     expect(fromMock).toHaveBeenCalledTimes(3);
   });
 
-  it("arma nombre_completo como base + tipo + sabor + tamaño", async () => {
+  it("no manda nombre_completo (lo deriva el trigger de BD) y sanitiza atributos", async () => {
     const { crearProductoManual } = await import("@/services/catalogo");
-    const dtoConSabor = {
+    const dtoSucio = {
       ean: "7777777777777",
       productoBase: { nombre: "Yerba", marca: "Playadito", categoria: "Almacén" },
-      variante: { tipo: "Con Palo", sabor: "Suave", tamano: "1kg" },
+      variante: { atributos: { tipo: " Con Palo ", sabor: "  ", tamano: "1kg" } },
     };
     let payloadInsertado: Record<string, unknown> | undefined;
     fromMock.mockImplementation((tabla: string) => {
@@ -128,7 +124,12 @@ describe("crearProductoManual", () => {
             return {
               select: () => ({
                 single: async () => ({
-                  data: { ...payload, id: "variante-nueva", created_at: "2026-01-01T00:00:00Z" },
+                  data: {
+                    ...payload,
+                    id: "variante-nueva",
+                    nombre_completo: "Yerba Con Palo 1kg", // lo pondría el trigger
+                    created_at: "2026-01-01T00:00:00Z",
+                  },
                   error: null,
                 }),
               }),
@@ -143,9 +144,10 @@ describe("crearProductoManual", () => {
       };
     });
 
-    await crearProductoManual(dtoConSabor);
+    await crearProductoManual(dtoSucio);
 
-    expect(payloadInsertado?.nombre_completo).toBe("Yerba Con Palo Suave 1kg");
+    expect(payloadInsertado).not.toHaveProperty("nombre_completo");
+    expect(payloadInsertado?.atributos).toEqual({ tipo: "Con Palo", tamano: "1kg" });
   });
 
   it("crea un producto base nuevo si no existe ninguno con ese nombre+marca", async () => {
@@ -155,10 +157,8 @@ describe("crearProductoManual", () => {
       id: "variante-nueva",
       producto_base_id: "base-nueva",
       codigo_barras: dto.ean,
-      nombre_completo: "Con Palo 1kg",
-      tipo: "Con Palo",
-      tamano: "1kg",
-      sabor: null,
+      nombre_completo: "Yerba Con Palo 1kg",
+      atributos: { tipo: "Con Palo", tamano: "1kg" },
       imagen: null,
       created_at: "2026-01-01T00:00:00Z",
     };
@@ -206,6 +206,36 @@ describe("obtenerProductosPorVarianteIds", () => {
     const resultado = await obtenerProductosPorVarianteIds(["variante-1"]);
     const restaurado = JSON.parse(JSON.stringify(resultado));
     expect(restaurado["variante-1"]?.base.nombre).toBe("Leche");
+  });
+});
+
+describe("obtenerDefinicionesAtributos", () => {
+  it("separa el default global (categoria null) de las definiciones por categoría", async () => {
+    const { obtenerDefinicionesAtributos } = await import("@/services/catalogo");
+    fromMock.mockImplementation(
+      mockSupabaseFrom({
+        data: [
+          { categoria: null, clave: "tipo", etiqueta: "Tipo", orden: 0, sugerencias: [] },
+          { categoria: null, clave: "sabor", etiqueta: "Sabor", orden: 1, sugerencias: [] },
+          {
+            categoria: "Ferretería",
+            clave: "medida",
+            etiqueta: "Medida",
+            orden: 0,
+            sugerencias: ["PH1", "PH2"],
+          },
+        ],
+      })
+    );
+
+    const defs = await obtenerDefinicionesAtributos();
+
+    expect(defs.default.map((d) => d.clave)).toEqual(["tipo", "sabor"]);
+    expect(defs.porCategoria["Ferretería"]).toEqual([
+      { clave: "medida", etiqueta: "Medida", orden: 0, sugerencias: ["PH1", "PH2"] },
+    ]);
+    // sugerencias vacías se normalizan a undefined (no ensuciar el JSON persistido)
+    expect(defs.default[0].sugerencias).toBeUndefined();
   });
 });
 

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -1,6 +1,11 @@
 import { supabase } from "@/lib/supabase";
-import { construirNombreCompleto } from "@/lib/utils";
-import { CrearProductoDTO, ProductoBase, ProductoVariante } from "@/types";
+import {
+  AtributosVariante,
+  CategoriaAtributo,
+  CrearProductoDTO,
+  ProductoBase,
+  ProductoVariante,
+} from "@/types";
 
 export interface ProductoCompleto {
   base: ProductoBase;
@@ -22,9 +27,7 @@ interface ProductoVarianteRow {
   producto_base_id: string;
   codigo_barras: string;
   nombre_completo: string;
-  tipo: string | null;
-  tamano: string | null;
-  sabor: string | null;
+  atributos: Record<string, string> | null;
   imagen: string | null;
   created_at: string;
 }
@@ -47,9 +50,9 @@ function mapProductoVariante(row: ProductoVarianteRow): ProductoVariante {
     productoBaseId: row.producto_base_id,
     codigoBarras: row.codigo_barras,
     nombreCompleto: row.nombre_completo,
-    tipo: row.tipo ?? undefined,
-    tamano: row.tamano ?? undefined,
-    sabor: row.sabor ?? undefined,
+    // `?? {}` defensivo: respuestas viejas o caché con shape anterior
+    // pueden no traer la clave; el resto del código asume objeto.
+    atributos: row.atributos ?? {},
     imagen: row.imagen ?? undefined,
     createdAt: new Date(row.created_at),
   };
@@ -170,6 +173,15 @@ export async function buscarVariantes(termino: string): Promise<ProductoCompleto
   return resultado;
 }
 
+/** Trim de claves y valores, descartando entradas vacías. */
+function sanitizarAtributos(atributos?: AtributosVariante): AtributosVariante {
+  return Object.fromEntries(
+    Object.entries(atributos ?? {})
+      .map(([clave, valor]) => [clave.trim(), String(valor).trim()])
+      .filter(([clave, valor]) => clave && valor)
+  );
+}
+
 /**
  * Crea un producto (base + variante) manualmente cuando el código escaneado
  * no está en el catálogo. Reutiliza el producto base si ya existe uno con
@@ -219,25 +231,16 @@ export async function crearProductoManual(
     baseRow = data as ProductoBaseRow;
   }
 
-  const nombreCompleto = [
-    dto.productoBase.nombre,
-    dto.variante.tipo,
-    dto.variante.sabor,
-    dto.variante.tamano,
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
-
+  // nombre_completo no se manda: es un campo derivado y su dueño es el
+  // trigger de BD (migración 0008), que lo arma desde atributos con el
+  // orden de la categoría. Así imports masivos o fixes por SQL nunca lo
+  // dejan desincronizado de la búsqueda ilike.
   const { data: varianteRow, error: varianteError } = await supabase
     .from("producto_variantes")
     .insert({
       producto_base_id: baseRow.id,
       codigo_barras: dto.ean.trim(),
-      nombre_completo: nombreCompleto,
-      tipo: dto.variante.tipo?.trim(),
-      tamano: dto.variante.tamano?.trim() || null,
-      sabor: dto.variante.sabor?.trim(),
+      atributos: sanitizarAtributos(dto.variante.atributos),
       imagen: dto.variante.imagen,
     })
     .select()
@@ -274,6 +277,50 @@ export async function obtenerProductosPorVarianteIds(
     const producto = mapProductoCompleto(row);
     if (!producto) continue;
     resultado[row.id] = producto;
+  }
+  return resultado;
+}
+
+interface CategoriaAtributoRow {
+  categoria: string | null;
+  clave: string;
+  etiqueta: string;
+  orden: number;
+  sugerencias: string[] | null;
+}
+
+export interface DefinicionesAtributos {
+  /** Claves del default global (filas con categoria null). */
+  default: CategoriaAtributo[];
+  /** Una categoría con >=1 fila REEMPLAZA al default (no mergea). */
+  porCategoria: Record<string, CategoriaAtributo[]>;
+}
+
+/**
+ * Definiciones de atributos por categoría: qué claves mostrar en el
+ * formulario dinámico, con qué etiqueta/orden y qué valores sugerir.
+ * La tabla es diminuta (unas filas por categoría), se trae entera.
+ */
+export async function obtenerDefinicionesAtributos(): Promise<DefinicionesAtributos> {
+  const { data, error } = await supabase
+    .from("categoria_atributos")
+    .select("categoria, clave, etiqueta, orden, sugerencias")
+    .order("orden");
+  if (error) throw error;
+
+  const resultado: DefinicionesAtributos = { default: [], porCategoria: {} };
+  for (const row of (data ?? []) as CategoriaAtributoRow[]) {
+    const def: CategoriaAtributo = {
+      clave: row.clave,
+      etiqueta: row.etiqueta,
+      orden: row.orden,
+      sugerencias: row.sugerencias?.length ? row.sugerencias : undefined,
+    };
+    if (row.categoria === null) {
+      resultado.default.push(def);
+    } else {
+      (resultado.porCategoria[row.categoria] ??= []).push(def);
+    }
   }
   return resultado;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,15 +30,31 @@ export interface ProductoBase {
   updatedAt: Date;
 }
 
+// Ejes de variación de una variante, clave->valor (ej: { tipo: "Sin
+// Lactosa", sabor: "Vainilla", tamano: "1L" }). Las claves las define
+// categoria_atributos por categoría; los valores son texto libre.
+// Objeto plano a propósito: se persiste en IndexedDB vía JSON.stringify.
+export type AtributosVariante = Record<string, string>;
+
+// Definición de un atributo para una categoría (tabla categoria_atributos):
+// guía el formulario dinámico y el orden de armado del nombre. Los valores
+// reales viven en ProductoVariante.atributos.
+export interface CategoriaAtributo {
+  clave: string;
+  etiqueta: string;
+  orden: number;
+  sugerencias?: string[];
+}
+
 // Variante de Producto
 export interface ProductoVariante {
   id: string; // UUID
   productoBaseId: string; // FK a ProductoBase
   codigoBarras: string;
+  // Derivado en BD (trigger): nombre base + atributos en el orden de la
+  // categoría. Nunca escribirlo desde el cliente.
   nombreCompleto: string;
-  tipo?: string; // "Original", "Sin Lactosa", etc.
-  tamano?: string; // "1000g", "1400g", etc.
-  sabor?: string;
+  atributos: AtributosVariante;
   imagen?: string;
   createdAt: Date;
 }
@@ -83,9 +99,7 @@ export interface CrearProductoDTO {
     imagen?: string;
   };
   variante: {
-    tipo?: string;
-    tamano?: string;
-    sabor?: string;
+    atributos?: AtributosVariante;
     imagen?: string;
   };
 }

--- a/supabase/migrations/0008_atributos_variantes.sql
+++ b/supabase/migrations/0008_atributos_variantes.sql
@@ -1,0 +1,177 @@
+-- Atributos flexibles por variante: los ejes de variación (tipo, sabor,
+-- tamano, y los que traiga cada categoría nueva) pasan de columnas fijas a
+-- un jsonb clave->valor en producto_variantes. Se elige jsonb por sobre EAV
+-- porque los caminos calientes de la app leen variante+base en un solo
+-- embed de PostgREST y el cliente persiste en IndexedDB via JSON.stringify:
+-- un objeto plano viaja en la misma fila sin joins ni re-ensamblaje.
+--
+-- categoria_atributos NO es EAV: los valores viven en el jsonb de la
+-- variante; esta tabla solo define qué claves mostrar por categoría, con
+-- qué etiqueta, en qué orden (formulario dinámico + armado de
+-- nombre_completo) y qué valores sugerir. categoria null = default global;
+-- una categoría con >=1 fila REEMPLAZA al default. Claves que no figuran
+-- en la definición van al final del nombre, en orden alfabético.
+--
+-- nombre_completo pasa a tener un solo dueño: el trigger de esta migración.
+-- Se recomputa en cada insert/update de la variante y al renombrar la base,
+-- así cualquier write path (API, import masivo, fix por SQL) lo deja
+-- consistente. La búsqueda ilike sobre nombre_completo depende de esto.
+--
+-- Las columnas legacy tipo/sabor/tamano NO se dropean acá: eso va en 0009,
+-- que debe aplicarse después del deploy del código que escribe atributos
+-- (los clientes viejos siguen insertando en las columnas legacy durante la
+-- ventana entre esta migración y el deploy).
+
+-- ============================================
+-- 1. Columna de atributos
+-- ============================================
+
+alter table producto_variantes
+  add column atributos jsonb not null default '{}'::jsonb;
+
+alter table producto_variantes
+  add constraint producto_variantes_atributos_es_objeto
+  check (jsonb_typeof(atributos) = 'object');
+
+-- ============================================
+-- 2. Backfill desde las columnas legacy
+-- ============================================
+
+update producto_variantes
+set atributos = jsonb_strip_nulls(jsonb_build_object(
+  'tipo',   nullif(trim(tipo), ''),
+  'sabor',  nullif(trim(sabor), ''),
+  'tamano', nullif(trim(tamano), '')
+))
+where coalesce(nullif(trim(tipo), ''), nullif(trim(sabor), ''),
+               nullif(trim(tamano), '')) is not null;
+
+-- ============================================
+-- 3. Índice GIN para filtros por contención (@>)
+-- ============================================
+
+create index idx_producto_variantes_atributos
+  on producto_variantes using gin (atributos jsonb_path_ops);
+
+-- ============================================
+-- 4. Definiciones de atributos por categoría
+-- ============================================
+
+create table categoria_atributos (
+  id uuid primary key default gen_random_uuid(),
+  categoria text,
+  clave text not null,
+  etiqueta text not null,
+  orden int not null default 0,
+  sugerencias text[] not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+create unique index categoria_atributos_categoria_clave_uq
+  on categoria_atributos (coalesce(categoria, ''), clave);
+
+alter table categoria_atributos enable row level security;
+create policy "allow_all_anon" on categoria_atributos
+  for all to anon, authenticated using (true) with check (true);
+
+-- Seed del default global: mismas claves y orden que el armado actual.
+insert into categoria_atributos (categoria, clave, etiqueta, orden) values
+  (null, 'tipo',   'Tipo',   0),
+  (null, 'sabor',  'Sabor',  1),
+  (null, 'tamano', 'Tamaño', 2);
+
+-- ============================================
+-- 5. nombre_completo: campo derivado con dueño único
+-- ============================================
+
+create or replace function armar_nombre_completo(
+  p_nombre_base text,
+  p_categoria text,
+  p_atributos jsonb
+)
+returns text
+language sql
+stable
+set search_path = public
+as $$
+  with defs as (
+    -- Definiciones de la categoría si tiene alguna; si no, las globales.
+    select clave, orden from categoria_atributos where categoria = p_categoria
+    union all
+    select clave, orden from categoria_atributos
+    where categoria is null
+      and not exists (
+        select 1 from categoria_atributos where categoria = p_categoria
+      )
+  )
+  select trim(concat_ws(' ',
+    p_nombre_base,
+    -- El guard de tipo evita que jsonb_each_text explote si llega un
+    -- no-objeto: el trigger BEFORE corre antes que el CHECK constraint,
+    -- y el rechazo claro debe darlo el CHECK, no esta función.
+    case when jsonb_typeof(p_atributos) = 'object' then (
+      select string_agg(a.valor, ' ' order by coalesce(d.orden, 999), a.clave)
+      from jsonb_each_text(p_atributos) as a(clave, valor)
+      left join defs d on d.clave = a.clave
+      where nullif(trim(a.valor), '') is not null
+    ) end
+  ))
+$$;
+
+-- Incondicional en UPDATE (no "update of atributos"): así ni un update
+-- manual de nombre_completo por SQL puede dejarlo desincronizado — siempre
+-- se deriva. En INSERT hay una excepción de compatibilidad para la ventana
+-- 0008→deploy: los clientes viejos mandan el nombre ya armado y dejan
+-- atributos vacío; se respeta su valor hasta que el re-backfill de 0009
+-- llene atributos (ese update dispara el recompute).
+create or replace function set_nombre_completo()
+returns trigger as $$
+declare
+  v_nombre text;
+  v_categoria text;
+begin
+  if tg_op = 'INSERT'
+     and new.atributos = '{}'::jsonb
+     and new.nombre_completo is not null then
+    return new;
+  end if;
+  select nombre, categoria into v_nombre, v_categoria
+  from producto_bases where id = new.producto_base_id;
+  new.nombre_completo = armar_nombre_completo(v_nombre, v_categoria, new.atributos);
+  return new;
+end;
+$$ language plpgsql set search_path = public;
+
+create trigger trg_producto_variantes_nombre_completo
+  before insert or update on producto_variantes
+  for each row
+  execute function set_nombre_completo();
+
+-- Renombrar la base (o cambiarle la categoría, que cambia el orden de las
+-- claves) propaga a los nombres de sus variantes. El SET de nombre_completo
+-- es solo para disparar el trigger BEFORE UPDATE, que es quien recomputa.
+create or replace function propagar_nombre_base()
+returns trigger as $$
+begin
+  update producto_variantes
+  set nombre_completo = nombre_completo
+  where producto_base_id = new.id;
+  return new;
+end;
+$$ language plpgsql set search_path = public;
+
+create trigger trg_producto_bases_propagar_nombre
+  after update on producto_bases
+  for each row
+  when (old.nombre is distinct from new.nombre
+        or old.categoria is distinct from new.categoria)
+  execute function propagar_nombre_base();
+
+-- ============================================
+-- 6. Recompute inicial: deja el stock existente consistente
+-- ============================================
+
+-- El SET dispara el trigger BEFORE UPDATE, que recomputa desde atributos.
+-- Puede alterar nombres legacy cuyo orden difiera del canónico (tipo,
+-- sabor, tamano); verificar el diff en local antes de aplicar en prod.
+update producto_variantes set nombre_completo = nombre_completo;

--- a/supabase/migrations/0009_drop_columnas_legacy_variantes.sql
+++ b/supabase/migrations/0009_drop_columnas_legacy_variantes.sql
@@ -1,0 +1,20 @@
+-- Cierra la transición a atributos jsonb iniciada en 0008. Aplicar DESPUÉS
+-- del deploy del código que escribe atributos: durante la ventana entre
+-- 0008 y el deploy, los clientes viejos siguieron insertando en las
+-- columnas legacy y dejaron atributos = '{}'. El re-backfill captura ese
+-- delta (y el trigger de 0008 recomputa nombre_completo solo).
+
+update producto_variantes
+set atributos = atributos || jsonb_strip_nulls(jsonb_build_object(
+  'tipo',   nullif(trim(tipo), ''),
+  'sabor',  nullif(trim(sabor), ''),
+  'tamano', nullif(trim(tamano), '')
+))
+where atributos = '{}'::jsonb
+  and coalesce(nullif(trim(tipo), ''), nullif(trim(sabor), ''),
+               nullif(trim(tamano), '')) is not null;
+
+alter table producto_variantes
+  drop column tipo,
+  drop column sabor,
+  drop column tamano;


### PR DESCRIPTION
## 📝 Descripción

Reemplaza las columnas fijas `tipo`/`sabor`/`tamano` de `producto_variantes` por una columna `atributos jsonb`, acompañada de una tabla `categoria_atributos` que define qué claves mostrar por categoría (etiqueta, orden, sugerencias). Cada categoría nueva (bebidas por sabor+volumen, ferretería por medida+material, etc.) se resuelve con datos, sin migración de schema.

`nombre_completo` pasa de armarse client-side a ser un campo derivado por trigger de BD (`armar_nombre_completo` + triggers en `producto_variantes` y `producto_bases`), así ningún write path (API, import masivo, fix por SQL) lo deja desincronizado de la búsqueda `ilike` que depende de él.

Se evaluaron tres alternativas (jsonb, EAV normalizado, híbrido de columnas universales + jsonb) y se documentó el trade-off en el header de la migración 0008: EAV rompía el patrón de 1-round-trip de PostgREST (`select("*, producto_bases(*)")`) y complicaba la persistencia en IndexedDB; el híbrido no tenía ejes realmente universales entre categorías (las 3 columnas actuales ya eran el sesgo de "producto de supermercado").

### Migraciones

- **0008** (ya aplicada en producción): agrega `atributos jsonb NOT NULL DEFAULT '{}'` + CHECK de objeto, backfill desde las columnas legacy, índice GIN (`jsonb_path_ops`) para filtros futuros por contención, tabla `categoria_atributos` con RLS + seed del default global, función `armar_nombre_completo` + triggers, y recompute inicial del catálogo existente (reparó 15 de 372 variantes con nombres ya desincronizados antes de este cambio).
- **0009** (pendiente — aplicar después de este deploy): re-backfill del delta de altas hechas por código viejo en la ventana entre 0008 y el deploy, y drop de `tipo`/`sabor`/`tamano`.

## 🎯 Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [x] 💥 Breaking change (cambio de schema; compatible con el código viejo mientras las columnas legacy sigan presentes)
- [ ] 📚 Documentación
- [ ] 🎨 Mejora de UI/UX
- [ ] ⚡ Mejora de rendimiento
- [ ] ♻️ Refactorización

## 🔗 Issue relacionado

N/A

## 🧪 Testing

- [x] Migraciones 0001→0009 replicadas en Postgres local (backfill, orden por categoría, shim de compatibilidad, dueño único del nombre, claves desconocidas al final, propagación de rename, re-backfill del delta, CHECK de objeto — 8 asserts en verde)
- [x] `npm run lint` sin errores (10 warnings preexistentes, no relacionados)
- [x] `npx vitest run`: 118 tests en verde (incluye casos nuevos de `construirNombreCompleto`/`ordenarClavesAtributos` y fixtures actualizadas)
- [x] `npm run build` OK (Node 22)
- [x] Verificado end-to-end contra producción: GET de definiciones, POST con canonicalización de valores (`"ph2"` → `"PH2"`), validación 400 de atributos mal formados, 409 de EAN duplicado, búsqueda ilike encontrando por atributo canonicalizado — datos de prueba limpiados
- [ ] Probado en Safari/Firefox
- [x] Funciona offline (PWA) — bump de `buster` a `v3` en `QueryProvider.tsx` para invalidar caché con el shape viejo de `ProductoVariante`
- [ ] Scanner de códigos de barras (no se tocó el flujo de escaneo, solo cómo deriva `tamano` desde `atributos`)

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] Auto-revisión realizada
- [x] Comentarios solo donde el WHY no es obvio (decisiones de la migración, dueño de `nombre_completo`, compatibilidad de la ventana de deploy)
- [x] Sin warnings nuevos
- [ ] Documentación externa (no aplica, no hay docs de schema fuera del repo)
- [x] Tests existentes pasan

## 📌 Notas adicionales

**Acción pendiente post-merge:** aplicar la migración `0009_drop_columnas_legacy_variantes.sql` en el proyecto Supabase recién esté este código deployado. Aplicarla antes rompería cualquier alta manual del código viejo en producción (sigue escribiendo en `tipo`/`sabor`/`tamano`).

🤖 Generado con [Claude Code](https://claude.com/claude-code)