### PR TITLE
Abaratar el parseo con IA: prompt caching + orden estable del catálogo

### DIFF
--- a/src/services/__tests__/parseoProducto.test.ts
+++ b/src/services/__tests__/parseoProducto.test.ts
@@ -135,12 +135,15 @@ describe("parsearProducto", () => {
     });
     expect(parsed.atributos).toEqual({ tamano: "2200g" });
 
-    // El contexto del catálogo viaja en el system prompt (matcheo canónico)
+    // El contexto del catálogo viaja en el system prompt (matcheo canónico),
+    // como bloque con cache_control para abaratar requests repetidos.
     const llamada = createMock.mock.calls[0][0];
     expect(llamada.model).toBe("claude-haiku-4-5");
-    expect(llamada.system).toContain("Milex");
-    expect(llamada.system).toContain("Leche Milex");
-    expect(llamada.system).toContain("Lácteos");
+    expect(llamada.system).toHaveLength(1);
+    expect(llamada.system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(llamada.system[0].text).toContain("Milex");
+    expect(llamada.system[0].text).toContain("Leche Milex");
+    expect(llamada.system[0].text).toContain("Lácteos");
     expect(llamada.messages).toEqual([
       { role: "user", content: "leche milex 2200 gramos" },
     ]);

--- a/src/services/parseoProducto.ts
+++ b/src/services/parseoProducto.ts
@@ -177,7 +177,14 @@ export async function parsearProducto(texto: string): Promise<ProductoParseado> 
   const [{ marcas, categorias }, defs, basesResult] = await Promise.all([
     obtenerMarcasYCategorias(),
     obtenerDefinicionesAtributos(),
-    supabase.from("producto_bases").select("nombre, marca, categoria"),
+    // El orden estable importa: el system prompt se cachea por prefijo exacto
+    // de bytes, y sin .order() Postgres no garantiza orden — cada request
+    // generaría un prompt distinto y el caché nunca pegaría.
+    supabase
+      .from("producto_bases")
+      .select("nombre, marca, categoria")
+      .order("nombre")
+      .order("marca"),
   ]);
   if (basesResult.error) throw basesResult.error;
   const bases = (basesResult.data ?? []) as BaseExistenteRow[];
@@ -185,7 +192,18 @@ export async function parsearProducto(texto: string): Promise<ProductoParseado> 
   const response = await client.messages.create({
     model: "claude-haiku-4-5",
     max_tokens: 1024,
-    system: construirSystemPrompt(marcas, categorias, defs, bases),
+    // El catálogo completo viaja en el system prompt y domina el costo del
+    // request. Con cache_control, requests dentro de la ventana del caché
+    // (5 min) pagan ~10% por el prefijo cacheado en vez del precio completo.
+    // Si el catálogo es chico (<4096 tokens, mínimo cacheable de Haiku 4.5)
+    // el marcador se ignora en silencio, sin costo extra.
+    system: [
+      {
+        type: "text",
+        text: construirSystemPrompt(marcas, categorias, defs, bases),
+        cache_control: { type: "ephemeral" },
+      },
+    ],
     output_config: {
       format: {
         type: "json_schema",


### PR DESCRIPTION
El system prompt lleva el catálogo completo (bases, marcas, categorías y
definiciones de atributos) en cada request, y eso domina el costo. Dos
cambios:

- cache_control ephemeral en el system prompt: requests dentro de la
  ventana de 5 min pagan ~10% por el prefijo cacheado en vez del precio
  completo de input.
- .order() en la query de producto_bases: sin orden estable, los bytes
  del prompt cambiaban entre requests y el caché nunca podía pegar.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JyJCR42dQnGnmhu5cZe5N9