### PR TITLE
Agregar Gemini como fallback del parseo con IA (transición desde Anthropic)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,15 @@ RATE_LIMIT_API=30        # Requests por minuto - API general
 RATE_LIMIT_SEARCH=20     # Requests por minuto - Búsqueda de productos
 RATE_LIMIT_CREATE=15     # Requests por minuto - Creación de productos
 
-# 🤖 Anthropic (parseo de productos con IA en el alta manual)
+# 🤖 IA (parseo de productos en el alta manual)
+# Proveedor principal: Anthropic (mientras haya crédito).
 # Crea tu API key en: https://console.anthropic.com/settings/keys
-# Sin esta variable el alta cae al formulario manual (la app no rompe).
 ANTHROPIC_API_KEY=sk-ant-api03-xxx
+
+# Fallback / reemplazo: Gemini free tier. Si la llamada a Anthropic falla
+# (crédito agotado, rate limit) o no hay ANTHROPIC_API_KEY, se usa Gemini.
+# Sin ninguna de las dos keys el alta cae al formulario manual (la app no rompe).
+# Crea tu API key en: https://aistudio.google.com/apikey
+GEMINI_API_KEY=AIzaSyxxx
+# Opcional: modelo de Gemini (default: gemini-3.1-flash-lite)
+# GEMINI_MODEL=gemini-3.1-flash-lite

--- a/src/services/__tests__/parseoProducto.test.ts
+++ b/src/services/__tests__/parseoProducto.test.ts
@@ -14,14 +14,21 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
+const fetchMock = vi.fn();
+
 beforeEach(() => {
   fromMock.mockReset();
   createMock.mockReset();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
   process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+  delete process.env.GEMINI_API_KEY;
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.GEMINI_API_KEY;
 });
 
 // parsearProducto trae contexto con 3 llamadas a supabase.from:
@@ -102,8 +109,24 @@ describe("mapearRespuestaParseo", () => {
   });
 });
 
+// Respuesta exitosa de Gemini generateContent con el JSON dado.
+function respuestaGemini(json: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      candidates: [
+        {
+          finishReason: "STOP",
+          content: { parts: [{ text: JSON.stringify(json) }] },
+        },
+      ],
+    }),
+  };
+}
+
 describe("parsearProducto", () => {
-  it("lanza IANoConfiguradaError sin ANTHROPIC_API_KEY (la route responde 503)", async () => {
+  it("lanza IANoConfiguradaError sin ninguna API key (la route responde 503)", async () => {
     delete process.env.ANTHROPIC_API_KEY;
     const { parsearProducto, IANoConfiguradaError } = await import(
       "@/services/parseoProducto"
@@ -112,6 +135,7 @@ describe("parsearProducto", () => {
       IANoConfiguradaError
     );
     expect(createMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("arma el prompt con el catálogo y devuelve el parseo mapeado", async () => {
@@ -154,6 +178,96 @@ describe("parsearProducto", () => {
     createMock.mockResolvedValue({
       stop_reason: "max_tokens",
       content: [{ type: "text", text: "{" }],
+    });
+    const { parsearProducto, ParseoInvalidoError } = await import(
+      "@/services/parseoProducto"
+    );
+    await expect(parsearProducto("algo")).rejects.toThrow(ParseoInvalidoError);
+  });
+
+  it("usa Gemini directamente cuando solo hay GEMINI_API_KEY", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.GEMINI_API_KEY = "AIza-test";
+    mockContexto();
+    fetchMock.mockResolvedValue(
+      respuestaGemini({
+        nombreBase: "Leche Milex",
+        marca: "Milex",
+        categoria: "Lácteos",
+        atributos: [{ clave: "tamano", valor: "2200g" }],
+      })
+    );
+    const { parsearProducto } = await import("@/services/parseoProducto");
+
+    const parsed = await parsearProducto("leche milex 2200g");
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(parsed.productoBase.nombre).toBe("Leche Milex");
+    expect(parsed.atributos).toEqual({ tamano: "2200g" });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("gemini-3.1-flash-lite:generateContent");
+    const body = JSON.parse(init.body);
+    // El catálogo viaja como systemInstruction también en Gemini
+    expect(body.systemInstruction.parts[0].text).toContain("Leche Milex");
+    expect(body.contents).toEqual([
+      { role: "user", parts: [{ text: "leche milex 2200g" }] },
+    ]);
+  });
+
+  it("cae a Gemini cuando Anthropic falla (ej: crédito agotado)", async () => {
+    process.env.GEMINI_API_KEY = "AIza-test";
+    mockContexto();
+    createMock.mockRejectedValue(
+      new Error("Your credit balance is too low to access the Anthropic API")
+    );
+    fetchMock.mockResolvedValue(
+      respuestaGemini({
+        nombreBase: "Compota",
+        marca: "Gerber",
+        categoria: "",
+        atributos: [],
+      })
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { parsearProducto } = await import("@/services/parseoProducto");
+
+    const parsed = await parsearProducto("compota gerber");
+
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(parsed.productoBase).toEqual({
+      nombre: "Compota",
+      marca: "Gerber",
+      categoria: undefined,
+    });
+    warnSpy.mockRestore();
+  });
+
+  it("propaga el error de Anthropic si Gemini no está configurado", async () => {
+    mockContexto();
+    createMock.mockRejectedValue(new Error("rate limited"));
+    const { parsearProducto } = await import("@/services/parseoProducto");
+
+    await expect(parsearProducto("algo")).rejects.toThrow("rate limited");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rechaza respuestas de Gemini con finishReason distinto de STOP", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.GEMINI_API_KEY = "AIza-test";
+    mockContexto();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        candidates: [
+          {
+            finishReason: "MAX_TOKENS",
+            content: { parts: [{ text: "{" }] },
+          },
+        ],
+      }),
     });
     const { parsearProducto, ParseoInvalidoError } = await import(
       "@/services/parseoProducto"

--- a/src/services/parseoProducto.ts
+++ b/src/services/parseoProducto.ts
@@ -7,13 +7,23 @@ import {
 import { AtributosVariante, ProductoParseado } from "@/types";
 import Anthropic from "@anthropic-ai/sdk";
 
-// Server-only: usa ANTHROPIC_API_KEY (sin NEXT_PUBLIC_). Importar este módulo
-// solo desde API routes; en el cliente no hay key y el flujo cae al form.
+// Server-only: usa ANTHROPIC_API_KEY / GEMINI_API_KEY (sin NEXT_PUBLIC_).
+// Importar este módulo solo desde API routes; en el cliente no hay key y el
+// flujo cae al form.
+//
+// Proveedores: Anthropic (Haiku 4.5) es el principal mientras haya crédito;
+// si su llamada falla (crédito agotado, rate limit, etc.) o no hay key, se
+// usa Gemini (free tier). Así la transición Anthropic → Gemini no requiere
+// deploy: cuando el crédito se acabe, el fallback entra solo.
+
+const GEMINI_MODEL_DEFAULT = "gemini-3.1-flash-lite";
 
 /** La route lo convierte en 503: la feature degrada al formulario manual. */
 export class IANoConfiguradaError extends Error {
   constructor() {
-    super("Falta ANTHROPIC_API_KEY: el parseo con IA no está configurado");
+    super(
+      "Falta ANTHROPIC_API_KEY o GEMINI_API_KEY: el parseo con IA no está configurado"
+    );
     this.name = "IANoConfiguradaError";
   }
 }
@@ -164,30 +174,11 @@ export function mapearRespuestaParseo(raw: unknown): ProductoParseado {
   };
 }
 
-/**
- * Parsea el texto libre de un producto ("Leche Milex Original 2200g") a
- * campos normalizados contra el catálogo existente, con Claude Haiku 4.5.
- */
-export async function parsearProducto(texto: string): Promise<ProductoParseado> {
-  if (!process.env.ANTHROPIC_API_KEY) {
-    throw new IANoConfiguradaError();
-  }
+async function parsearConAnthropic(
+  texto: string,
+  systemPrompt: string
+): Promise<ProductoParseado> {
   const client = new Anthropic();
-
-  const [{ marcas, categorias }, defs, basesResult] = await Promise.all([
-    obtenerMarcasYCategorias(),
-    obtenerDefinicionesAtributos(),
-    // El orden estable importa: el system prompt se cachea por prefijo exacto
-    // de bytes, y sin .order() Postgres no garantiza orden — cada request
-    // generaría un prompt distinto y el caché nunca pegaría.
-    supabase
-      .from("producto_bases")
-      .select("nombre, marca, categoria")
-      .order("nombre")
-      .order("marca"),
-  ]);
-  if (basesResult.error) throw basesResult.error;
-  const bases = (basesResult.data ?? []) as BaseExistenteRow[];
 
   const response = await client.messages.create({
     model: "claude-haiku-4-5",
@@ -200,7 +191,7 @@ export async function parsearProducto(texto: string): Promise<ProductoParseado> 
     system: [
       {
         type: "text",
-        text: construirSystemPrompt(marcas, categorias, defs, bases),
+        text: systemPrompt,
         cache_control: { type: "ephemeral" },
       },
     ],
@@ -222,4 +213,121 @@ export async function parsearProducto(texto: string): Promise<ProductoParseado> 
   }
 
   return mapearRespuestaParseo(JSON.parse(bloqueTexto.text));
+}
+
+// Gemini no recibe el json_schema de structured outputs (su responseSchema
+// usa otro dialecto), así que la forma esperada se describe en el prompt y
+// mapearRespuestaParseo valida el shape igual que con Anthropic.
+const INSTRUCCION_JSON_GEMINI = [
+  "",
+  "Respondé ÚNICAMENTE con un objeto JSON (sin markdown, sin texto extra) con esta forma exacta:",
+  '{"nombreBase": "...", "marca": "...", "categoria": "...", "atributos": [{"clave": "...", "valor": "..."}]}',
+  "nombreBase: el producto conceptual, sin marca ni atributos de variación.",
+  "categoria: una existente si encaja, una nueva solo si ninguna aplica, cadena vacía si no se puede determinar.",
+].join("\n");
+
+interface GeminiParte {
+  text?: string;
+}
+
+async function parsearConGemini(
+  texto: string,
+  systemPrompt: string
+): Promise<ProductoParseado> {
+  const modelo = process.env.GEMINI_MODEL || GEMINI_MODEL_DEFAULT;
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${modelo}:generateContent`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-goog-api-key": process.env.GEMINI_API_KEY as string,
+      },
+      body: JSON.stringify({
+        systemInstruction: {
+          parts: [{ text: systemPrompt + INSTRUCCION_JSON_GEMINI }],
+        },
+        contents: [{ role: "user", parts: [{ text: texto }] }],
+        generationConfig: {
+          responseMimeType: "application/json",
+          maxOutputTokens: 2048,
+        },
+      }),
+    }
+  );
+
+  if (!res.ok) {
+    const cuerpo = await res.text().catch(() => "");
+    throw new ParseoInvalidoError(
+      `Gemini HTTP ${res.status}: ${cuerpo.slice(0, 200)}`
+    );
+  }
+
+  const data = (await res.json()) as {
+    candidates?: Array<{
+      finishReason?: string;
+      content?: { parts?: GeminiParte[] };
+    }>;
+  };
+  const candidato = data.candidates?.[0];
+  if (candidato?.finishReason && candidato.finishReason !== "STOP") {
+    throw new ParseoInvalidoError(`Gemini finishReason: ${candidato.finishReason}`);
+  }
+  const textoRespuesta = (candidato?.content?.parts ?? [])
+    .map((p) => (typeof p.text === "string" ? p.text : ""))
+    .join("");
+  if (!textoRespuesta) {
+    throw new ParseoInvalidoError("Gemini: respuesta sin texto");
+  }
+
+  return mapearRespuestaParseo(JSON.parse(textoRespuesta));
+}
+
+/**
+ * Parsea el texto libre de un producto ("Leche Milex Original 2200g") a
+ * campos normalizados contra el catálogo existente.
+ *
+ * Anthropic (Haiku 4.5) mientras haya key y crédito; Gemini como fallback
+ * automático (o único proveedor si solo hay GEMINI_API_KEY).
+ */
+export async function parsearProducto(texto: string): Promise<ProductoParseado> {
+  const anthropicConfigurado = Boolean(process.env.ANTHROPIC_API_KEY);
+  const geminiConfigurado = Boolean(process.env.GEMINI_API_KEY);
+  if (!anthropicConfigurado && !geminiConfigurado) {
+    throw new IANoConfiguradaError();
+  }
+
+  const [{ marcas, categorias }, defs, basesResult] = await Promise.all([
+    obtenerMarcasYCategorias(),
+    obtenerDefinicionesAtributos(),
+    // El orden estable importa: el system prompt se cachea por prefijo exacto
+    // de bytes, y sin .order() Postgres no garantiza orden — cada request
+    // generaría un prompt distinto y el caché nunca pegaría.
+    supabase
+      .from("producto_bases")
+      .select("nombre, marca, categoria")
+      .order("nombre")
+      .order("marca"),
+  ]);
+  if (basesResult.error) throw basesResult.error;
+  const bases = (basesResult.data ?? []) as BaseExistenteRow[];
+
+  const systemPrompt = construirSystemPrompt(marcas, categorias, defs, bases);
+
+  if (!anthropicConfigurado) {
+    return parsearConGemini(texto, systemPrompt);
+  }
+  try {
+    return await parsearConAnthropic(texto, systemPrompt);
+  } catch (error) {
+    if (!geminiConfigurado) throw error;
+    // Crédito agotado, rate limit o cualquier fallo del proveedor principal:
+    // el mismo request se resuelve con el fallback en vez de romper el alta.
+    console.warn(
+      "Parseo con Anthropic falló; reintentando con Gemini:",
+      error instanceof Error ? error.message : error
+    );
+    return parsearConGemini(texto, systemPrompt);
+  }
 }


### PR DESCRIPTION
Decisión: agotar el crédito restante de Anthropic y luego pasar a Gemini free tier. Para que la transición no requiera deploy:

- Anthropic (Haiku 4.5) sigue siendo el proveedor principal mientras haya ANTHROPIC_API_KEY y la llamada funcione.
- Si la llamada a Anthropic falla (crédito agotado, rate limit, etc.) y hay GEMINI_API_KEY, el mismo request se resuelve con Gemini (gemini-3.1-flash-lite, configurable vía GEMINI_MODEL).
- Con solo GEMINI_API_KEY, Gemini es el único proveedor.
- Sin ninguna key, el alta sigue cayendo al formulario manual (503).

Gemini no recibe el json_schema de structured outputs (dialecto distinto), así que la forma esperada se describe en el prompt y mapearRespuestaParseo valida el shape igual que con Anthropic.

Claude-Session: https://claude.ai/code/session_01JyJCR42dQnGnmhu5cZe5N9

## 📝 Descripción

<!-- Describe los cambios realizados en este PR -->

## 🎯 Tipo de cambio

- [ ] 🐛 Bug fix (cambio que corrige un problema)
- [ ] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [ ] 💥 Breaking change (cambio que rompe compatibilidad)
- [ ] 📚 Documentación
- [ ] 🎨 Mejora de UI/UX
- [ ] ⚡ Mejora de rendimiento
- [ ] ♻️ Refactorización

## 🔗 Issue relacionado

<!-- Cierra #(número del issue) -->

## 🧪 Testing

- [ ] Probado en Chrome/Edge
- [ ] Probado en Safari
- [ ] Probado en Firefox
- [ ] Probado en móvil
- [ ] Funciona offline (PWA)
- [ ] Scanner de códigos de barras funcional

## ✅ Checklist

- [ ] El código sigue las guías de estilo del proyecto
- [ ] He realizado una auto-revisión de mi código
- [ ] He comentado el código en áreas difíciles de entender
- [ ] Mis cambios no generan warnings nuevos
- [ ] He actualizado la documentación correspondiente
- [ ] Los tests existentes pasan correctamente

## 📸 Screenshots (si aplica)

<!-- Agrega screenshots de cambios visuales -->

## 🎯 Instrucciones de testing

1.
2.
3.

## 📌 Notas adicionales

<!-- Cualquier información adicional que los revisores deban conocer -->
