### PR TITLE
Unicidad case-insensitive de bases tras la limpieza del catálogo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,4 +17,4 @@ RATE_LIMIT_CREATE=15     # Requests por minuto - Creación de productos
 # 🤖 Anthropic (parseo de productos con IA en el alta manual)
 # Crea tu API key en: https://console.anthropic.com/settings/keys
 # Sin esta variable el alta cae al formulario manual (la app no rompe).
-ANTHROPIC_API_KEY=sk-ant-api03-xxx
+ANTHROPIC_API_KEY=tu_api_key_aqui

--- a/src/services/__tests__/catalogo.test.ts
+++ b/src/services/__tests__/catalogo.test.ts
@@ -139,7 +139,8 @@ describe("crearProductoManual", () => {
       }
       return {
         select: () => ({
-          eq: () => ({ eq: () => ({ maybeSingle: async () => ({ data: baseRow, error: null }) }) }),
+          // El lookup de base usa ilike (igualdad case-insensitive, ver 0010)
+          ilike: () => ({ ilike: () => ({ maybeSingle: async () => ({ data: baseRow, error: null }) }) }),
         }),
       };
     });

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -202,11 +202,14 @@ export async function crearProductoManual(
       .select("id")
       .eq("codigo_barras", dto.ean)
       .maybeSingle(),
+    // ilike sin comodines = igualdad case-insensitive: reutiliza la base
+    // aunque el tipeo difiera en mayúsculas ("MILEX" → base "Milex"), en
+    // vez de chocar con el índice único de la migración 0010.
     supabase
       .from("producto_bases")
       .select("*")
-      .eq("nombre", dto.productoBase.nombre.trim())
-      .eq("marca", dto.productoBase.marca.trim())
+      .ilike("nombre", dto.productoBase.nombre.trim())
+      .ilike("marca", dto.productoBase.marca.trim())
       .maybeSingle(),
   ]);
   if (buscarError) throw buscarError;

--- a/supabase/migrations/0010_unicidad_bases.sql
+++ b/supabase/migrations/0010_unicidad_bases.sql
@@ -1,0 +1,25 @@
+-- Hardening post-limpieza del catálogo (jul 2026): la BD pasa a garantizar
+-- lo que la limpieza dejó — una sola base por (nombre, marca) sin importar
+-- mayúsculas ni espacios. El flujo de alta con IA ya matchea canónico; este
+-- índice cierra el camino manual/Corregir, que podía recrear duplicados
+-- ("MILEX" vs "Milex"). crearProductoManual busca la base existente con
+-- ilike (case-insensitive) para reutilizar en vez de chocar con el índice.
+
+-- 1. El trigger de normalización ahora también trimea nombre (el caso
+--    "Ritz " vs "Ritz": dos bases distintas por un espacio al final).
+create or replace function normalizar_marca_categoria()
+returns trigger as $$
+begin
+  new.nombre = trim(new.nombre);
+  new.marca = nullif(trim(new.marca), '');
+  new.categoria = nullif(trim(new.categoria), '');
+  return new;
+end;
+$$ language plpgsql set search_path = public;
+
+-- Backfill del trim de nombre en filas existentes.
+update producto_bases set nombre = trim(nombre) where nombre is distinct from trim(nombre);
+
+-- 2. Unicidad case-insensitive de base por nombre+marca.
+create unique index producto_bases_nombre_marca_uq
+  on producto_bases (lower(trim(nombre)), lower(trim(coalesce(marca, ''))));


### PR DESCRIPTION
## 📝 Descripción

Cierre de la limpieza/normalización del catálogo (ejecutada vía SQL sobre producción con backups y gates de confirmación): esta migración hace que la BD **garantice** lo que la limpieza dejó.

**La limpieza aplicada (contexto, no está en este diff):** 121→109 bases (8 duplicados exactos/semánticos mergeados, 4 huérfanas borradas, familia Orbis consolidada, base Sleepy des-mezclada en Pañales/Natural/Wipes), categorías unificadas (Detergente/De→Detergentes, Proteína/Proteinas→Proteínas, Cafes→Cafés), ~30 tallas de pañales normalizadas al formato P/1…XXXXG/7, fragancias de limpieza migradas de "sabor" a la clave nueva "fragancia" con definiciones por categoría, typos corregidos, y 69 definiciones por categoría sembradas con sugerencias desde los valores limpios (alimentan datalist + canonicalización + contexto del parseo IA).

**Este PR (el hardening):**
- `0010_unicidad_bases.sql`: `normalizar_marca_categoria()` ahora trimea también `nombre`; índice único sobre `(lower(trim(nombre)), lower(trim(marca)))`.
- `crearProductoManual`: el lookup de base existente pasa a `ilike` (igualdad case-insensitive) — "MILEX" reutiliza la base "Milex" en vez de chocar con el índice.

## 🎯 Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [ ] 💥 Breaking change
- [ ] 📚 Documentación
- [ ] 🎨 Mejora de UI/UX
- [ ] ⚡ Mejora de rendimiento
- [x] ♻️ Refactorización (integridad de datos)

## 🔗 Issue relacionado

Continuación de #87 (el alta con IA frena la contaminación nueva; esto limpia y blinda el stock existente).

## 🧪 Testing

- [x] Migración 0010 verificada en Postgres local con replay 0001→0010: backfill del trim, trim en inserts nuevos, índice rechaza duplicados case-insensitive (incluida marca null)
- [x] `npx vitest run`: 124 tests en verde (mock del lookup actualizado a ilike)
- [x] `npm run lint` sin errores, `npm run build` OK
- [x] Pre-verificación en producción: cero duplicados case-insensitive antes del índice

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] Auto-revisión realizada
- [x] Sin warnings nuevos
- [x] Los tests existentes pasan

## 📌 Notas adicionales

**Post-merge:** aplicar la migración 0010 en el proyecto Supabase. Las tablas `_backup_20260706_*` (121 bases / 402 variantes pre-limpieza) quedan en producción hasta confirmar que todo está bien; después se borran.

🤖 Generado con [Claude Code](https://claude.com/claude-code)