### PR TITLE
Catálogo offline-first: buscar y escanear funcionan sin red

### DIFF
--- a/src/app/api/productos/crear-manual/route.ts
+++ b/src/app/api/productos/crear-manual/route.ts
@@ -111,6 +111,12 @@ export async function POST(request: NextRequest) {
  *
  * Devuelve marcas y categorías existentes para autocompletado, más las
  * definiciones de atributos que arman el formulario dinámico del alta.
+ *
+ * TODO: sin consumidores desde jul 2026 — useMarcasCategorias ahora deriva
+ * del catálogo completo cacheado (ver useCatalogoCompleto) en vez de
+ * pegarle a este endpoint. Se deja como red de recuperación por si ese
+ * cache nunca carga; considerar remover si en unos meses se confirma que
+ * nadie lo llama.
  */
 export async function GET() {
   try {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Toaster } from "react-hot-toast";
 import "./globals.css";
+import CatalogoSyncProvider from "@/components/CatalogoSyncProvider";
 import OutboxProvider from "@/components/OutboxProvider";
 import PWAProvider from "./PWAProvider";
 import { QueryProvider } from "./QueryProvider";
@@ -104,6 +105,7 @@ export default function RootLayout({
           <ThemeProvider>
             <PWAProvider />
             <OutboxProvider />
+            <CatalogoSyncProvider />
             <Toaster
               position="top-center"
               containerStyle={{ top: "calc(env(safe-area-inset-top, 0px) + 64px)" }}

--- a/src/components/CatalogoSyncProvider.tsx
+++ b/src/components/CatalogoSyncProvider.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
+import { obtenerCatalogoCompleto } from "@/services/catalogo";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+/**
+ * Mantiene el catálogo completo (bases + variantes + definiciones) fresco
+ * en cache: prefetch al montar (si hay conexión) y refresh en cada evento
+ * `online`, para que escanear/buscar offline use datos recientes en vez de
+ * esperar al primer miss de useCatalogoCompleto.
+ *
+ * Separado de OutboxProvider a propósito: ese sincroniza la cola de
+ * mutaciones offline, esto sincroniza una lectura de catálogo —
+ * responsabilidades distintas aunque el patrón (montar + evento online)
+ * sea el mismo.
+ */
+export default function CatalogoSyncProvider() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const sincronizar = () =>
+      queryClient.prefetchQuery({
+        queryKey: CATALOGO_COMPLETO_KEY,
+        queryFn: obtenerCatalogoCompleto,
+        staleTime: 30 * 60_000,
+      });
+
+    if (navigator.onLine) sincronizar();
+    window.addEventListener("online", sincronizar);
+    return () => window.removeEventListener("online", sincronizar);
+  }, [queryClient]);
+
+  return null;
+}

--- a/src/components/scanner/ScanFlow.tsx
+++ b/src/components/scanner/ScanFlow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
 import { useHaptics } from "@/hooks/useHaptics";
-import { fetchMarcasCategorias, MARCAS_CATEGORIAS_KEY } from "@/hooks/useMarcasCategorias";
 import { ProductoEscaneado, useScanProduct } from "@/hooks/useScanProduct";
 import {
   useActualizarCantidadReposicion,
@@ -9,6 +9,7 @@ import {
   useEliminarReposicionItemDirecto,
 } from "@/hooks/useReposicion";
 import { useAgregarVencimientoItem } from "@/hooks/useVencimiento";
+import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useRecentsStore } from "@/store/recents";
 import { ScanMode } from "@/types";
 import { useQueryClient } from "@tanstack/react-query";
@@ -73,14 +74,17 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
   const registrarUso = useRecentsStore((s) => s.registrarUso);
   const queryClient = useQueryClient();
 
-  // Precargar marcas/categorías al abrir la cámara: si el código escaneado
-  // no está en el catálogo, el ManualProductSheet abre con el autocompletado
-  // ya listo en vez de esperar el round-trip.
+  // Precargar el catálogo completo al abrir la cámara: si el código
+  // escaneado no está, el ManualProductSheet abre con el autocompletado
+  // ya listo, y el lookup de EAN tiene un fallback local si falla la red.
+  // Redundante con CatalogoSyncProvider (que ya lo hace al montar la app),
+  // pero cubre el caso de abrir el escáner offline y recuperar señal recién
+  // acá — React Query dedupe si ambos disparan casi simultáneo.
   useEffect(() => {
     queryClient.prefetchQuery({
-      queryKey: MARCAS_CATEGORIAS_KEY,
-      queryFn: fetchMarcasCategorias,
-      staleTime: 5 * 60_000,
+      queryKey: CATALOGO_COMPLETO_KEY,
+      queryFn: obtenerCatalogoCompleto,
+      staleTime: 30 * 60_000,
     });
   }, []);
 
@@ -191,6 +195,11 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
   const handleProductoCreado = (producto: ProductoEscaneado) => {
     if (state.mode !== "unknown") return;
     seedProducto(state.ean, producto);
+    // La creación requiere red, así que el catálogo local quedó un producto
+    // atrás: invalidar dispara un refetch inmediato en vez de esperar el
+    // próximo sync. Más simple que mergear a mano (acá solo tenemos el
+    // ProductoEscaneado reducido, no el ProductoCompleto completo).
+    queryClient.invalidateQueries({ queryKey: CATALOGO_COMPLETO_KEY });
     dispatch({ type: "CREATED", producto });
   };
 

--- a/src/hooks/__tests__/useScanProduct.test.tsx
+++ b/src/hooks/__tests__/useScanProduct.test.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
 import { eanQueryKey, useScanProduct } from "@/hooks/useScanProduct";
-import type { ProductoCompleto } from "@/services/catalogo";
+import type { CatalogoCompleto, ProductoCompleto } from "@/services/catalogo";
 
 vi.mock("@/services/catalogo", () => ({
   buscarPorCodigoBarras: vi.fn(),
@@ -71,6 +72,45 @@ describe("useScanProduct", () => {
       new Error("TypeError: Failed to fetch")
     );
     const { result } = setup();
+
+    const res = await result.current.scanProduct("7790000000001");
+    expect(res.status).toBe("error");
+  });
+
+  it("red caída + catálogo local cacheado tiene el EAN → found (fallback offline)", async () => {
+    const { buscarPorCodigoBarras } = await import("@/services/catalogo");
+    vi.mocked(buscarPorCodigoBarras).mockRejectedValue(
+      new Error("TypeError: Failed to fetch")
+    );
+    const queryClient = new QueryClient();
+    const catalogo: CatalogoCompleto = {
+      bases: [PRODUCTO.base],
+      variantes: [PRODUCTO.variante],
+      definiciones: { default: [], porCategoria: {} },
+    };
+    queryClient.setQueryData(CATALOGO_COMPLETO_KEY, catalogo);
+    const { result } = setup(queryClient);
+
+    const res = await result.current.scanProduct("7790000000001");
+
+    expect(res.status).toBe("found");
+    if (res.status !== "found") throw new Error("unreachable");
+    expect(res.producto.variante.id).toBe("var-1");
+  });
+
+  it("red caída + catálogo local cacheado NO tiene el EAN → error", async () => {
+    const { buscarPorCodigoBarras } = await import("@/services/catalogo");
+    vi.mocked(buscarPorCodigoBarras).mockRejectedValue(
+      new Error("TypeError: Failed to fetch")
+    );
+    const queryClient = new QueryClient();
+    const catalogo: CatalogoCompleto = {
+      bases: [],
+      variantes: [],
+      definiciones: { default: [], porCategoria: {} },
+    };
+    queryClient.setQueryData(CATALOGO_COMPLETO_KEY, catalogo);
+    const { result } = setup(queryClient);
 
     const res = await result.current.scanProduct("7790000000001");
     expect(res.status).toBe("error");

--- a/src/hooks/useBuscarVariantes.ts
+++ b/src/hooks/useBuscarVariantes.ts
@@ -1,18 +1,23 @@
 "use client";
 
-import { buscarVariantes } from "@/services/catalogo";
-import { useQuery } from "@tanstack/react-query";
+import { buscarVariantesLocal } from "@/lib/catalogoLocal";
+import { useMemo } from "react";
+import { useCatalogoCompleto } from "./useCatalogoCompleto";
 import { useDebouncedValue } from "./useDebouncedValue";
 
-/** Autocompletado de productos por nombre/marca, debounced y cacheado por término. */
+/**
+ * Autocompletado de productos por nombre/marca, debounced. Filtra el
+ * catálogo completo ya cacheado (useCatalogoCompleto): instantáneo, sin
+ * round-trip propio, funciona offline.
+ */
 export function useBuscarVariantes(termino: string) {
   const debounced = useDebouncedValue(termino.trim(), 250);
+  const { data: catalogo, isLoading, isFetching } = useCatalogoCompleto();
 
-  return useQuery({
-    queryKey: ["catalogo", "buscar", debounced],
-    queryFn: () => buscarVariantes(debounced),
-    enabled: debounced.length >= 2,
-    staleTime: 5 * 60_000,
-    placeholderData: (previous) => previous,
-  });
+  const data = useMemo(() => {
+    if (!catalogo || debounced.length < 2) return [];
+    return buscarVariantesLocal(catalogo, debounced);
+  }, [catalogo, debounced]);
+
+  return { data, isLoading, isFetching: isFetching && debounced.length >= 2 };
 }

--- a/src/hooks/useCatalogoCompleto.ts
+++ b/src/hooks/useCatalogoCompleto.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { obtenerCatalogoCompleto } from "@/services/catalogo";
+import { useQuery } from "@tanstack/react-query";
+
+export const CATALOGO_COMPLETO_KEY = ["catalogo", "completo"] as const;
+
+/**
+ * Todo el catálogo (bases + variantes + definiciones de atributos) en una
+ * sola query, persistida en IndexedDB: es la fuente para lookup/búsqueda
+ * offline (ver src/lib/catalogoLocal.ts). staleTime alto porque el
+ * catálogo cambia con poca frecuencia comparado con las listas activas.
+ */
+export function useCatalogoCompleto() {
+  return useQuery({
+    queryKey: CATALOGO_COMPLETO_KEY,
+    queryFn: obtenerCatalogoCompleto,
+    staleTime: 30 * 60_000,
+  });
+}

--- a/src/hooks/useMarcasCategorias.ts
+++ b/src/hooks/useMarcasCategorias.ts
@@ -1,7 +1,9 @@
 "use client";
 
+import { obtenerMarcasYCategoriasLocal } from "@/lib/catalogoLocal";
 import { CategoriaAtributo } from "@/types";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useCatalogoCompleto } from "./useCatalogoCompleto";
 
 export interface MarcasCategorias {
   marcas: string[];
@@ -10,25 +12,24 @@ export interface MarcasCategorias {
   atributosPorCategoria: Record<string, CategoriaAtributo[]>;
 }
 
-export const MARCAS_CATEGORIAS_KEY = ["catalogo", "marcas-categorias"] as const;
-
-export async function fetchMarcasCategorias(): Promise<MarcasCategorias> {
-  const res = await fetch("/api/productos/crear-manual");
-  const data = await res.json();
-  return {
-    marcas: data.marcas ?? [],
-    categorias: data.categorias ?? [],
-    atributosDefault: data.atributosDefault ?? [],
-    atributosPorCategoria: data.atributosPorCategoria ?? {},
-  };
-}
-
-/** Marcas/categorías existentes, para el autocompletado del alta manual. */
+/**
+ * Marcas/categorías/atributos existentes, para el autocompletado del alta
+ * manual. Deriva del catálogo completo ya cacheado (useCatalogoCompleto):
+ * sin round-trip propio, funciona offline.
+ */
 export function useMarcasCategorias(enabled: boolean) {
-  return useQuery({
-    queryKey: MARCAS_CATEGORIAS_KEY,
-    queryFn: fetchMarcasCategorias,
-    enabled,
-    staleTime: 5 * 60_000,
-  });
+  const { data: catalogo, isLoading } = useCatalogoCompleto();
+
+  const data = useMemo<MarcasCategorias | undefined>(() => {
+    if (!enabled || !catalogo) return undefined;
+    const { marcas, categorias } = obtenerMarcasYCategoriasLocal(catalogo);
+    return {
+      marcas,
+      categorias,
+      atributosDefault: catalogo.definiciones.default,
+      atributosPorCategoria: catalogo.definiciones.porCategoria,
+    };
+  }, [catalogo, enabled]);
+
+  return { data, isLoading: enabled && isLoading };
 }

--- a/src/hooks/useProductosDeItems.ts
+++ b/src/hooks/useProductosDeItems.ts
@@ -1,17 +1,29 @@
 "use client";
 
-import { obtenerProductosPorVarianteIds } from "@/services/catalogo";
-import { useQuery } from "@tanstack/react-query";
+import { obtenerProductosPorVarianteIdsLocal } from "@/lib/catalogoLocal";
+import { useMemo } from "react";
+import { useCatalogoCompleto } from "./useCatalogoCompleto";
 
-/** Trae base+variante para un conjunto de varianteId, para renderizar listas de items. */
+/**
+ * Trae base+variante para un conjunto de varianteId, para renderizar listas
+ * de items. Deriva del catálogo completo ya cacheado (useCatalogoCompleto):
+ * sin round-trip propio, funciona offline apenas el catálogo sincronizó.
+ */
 export function useProductosDeItems(varianteIds: string[]) {
   const idsOrdenados = [...varianteIds].sort();
-  return useQuery({
-    queryKey: ["catalogo", "por-variante-ids", idsOrdenados],
-    queryFn: () => obtenerProductosPorVarianteIds(idsOrdenados),
-    enabled: idsOrdenados.length > 0,
-    // El catálogo (nombre/marca/tamaño de un producto) cambia muy rara vez
-    // comparado con los items de las listas: evita refetch constante.
-    staleTime: 10 * 60_000,
-  });
+  const idsKey = idsOrdenados.join(",");
+  const { data: catalogo, isLoading: catalogoIsLoading, isFetching } = useCatalogoCompleto();
+
+  // Depende de idsKey (string estable), no de idsOrdenados (array nuevo en
+  // cada render) — evita recalcular si el conjunto de ids es el mismo.
+  const data = useMemo(() => {
+    if (!catalogo || idsOrdenados.length === 0) return undefined;
+    return obtenerProductosPorVarianteIdsLocal(catalogo, idsOrdenados);
+  }, [catalogo, idsKey]);
+
+  return {
+    data,
+    isLoading: catalogoIsLoading && idsOrdenados.length > 0,
+    isFetching,
+  };
 }

--- a/src/hooks/useScanProduct.ts
+++ b/src/hooks/useScanProduct.ts
@@ -1,12 +1,30 @@
 "use client";
 
-import { buscarPorCodigoBarras } from "@/services/catalogo";
+import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
+import { buscarPorCodigoBarrasLocal } from "@/lib/catalogoLocal";
+import { buscarPorCodigoBarras, CatalogoCompleto, ProductoCompleto } from "@/services/catalogo";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 export interface ProductoEscaneado {
   base: { id: string; nombre: string; marca?: string; categoria?: string };
   variante: { id: string; nombreCompleto: string; tamano?: string };
+}
+
+function aProductoEscaneado(resultado: ProductoCompleto): ProductoEscaneado {
+  return {
+    base: {
+      id: resultado.base.id,
+      nombre: resultado.base.nombre,
+      marca: resultado.base.marca,
+      categoria: resultado.base.categoria,
+    },
+    variante: {
+      id: resultado.variante.id,
+      nombreCompleto: resultado.variante.nombreCompleto,
+      tamano: resultado.variante.atributos["tamano"],
+    },
+  };
 }
 
 /**
@@ -45,19 +63,7 @@ export function useScanProduct() {
         const resultado = await buscarPorCodigoBarras(barcode);
         if (!resultado) return { status: "not_found" };
 
-        const producto: ProductoEscaneado = {
-          base: {
-            id: resultado.base.id,
-            nombre: resultado.base.nombre,
-            marca: resultado.base.marca,
-            categoria: resultado.base.categoria,
-          },
-          variante: {
-            id: resultado.variante.id,
-            nombreCompleto: resultado.variante.nombreCompleto,
-            tamano: resultado.variante.atributos["tamano"],
-          },
-        };
+        const producto = aProductoEscaneado(resultado);
         queryClient.setQueryData(eanQueryKey(barcode), producto, {
           updatedAt: Date.now(),
         });
@@ -66,8 +72,26 @@ export function useScanProduct() {
         });
         return { status: "found", producto };
       } catch {
-        // maybeSingle() devuelve null para "no existe"; cualquier throw
-        // es un fallo del lookup (red, servidor), nunca un "no está".
+        // Red caída (o cualquier error real: maybeSingle() ya devuelve null
+        // para "no existe", nunca throwea por ausencia). Antes de rendirse,
+        // probar el catálogo local ya sincronizado — prioriza exactitud
+        // online (por eso este fallback vive en el catch, no reemplaza la
+        // llamada de red) pero evita bloquear un escaneo offline de un
+        // producto que sí está en el catálogo cacheado.
+        const catalogo = queryClient.getQueryData<CatalogoCompleto>(CATALOGO_COMPLETO_KEY);
+        if (catalogo) {
+          const resultadoLocal = buscarPorCodigoBarrasLocal(catalogo, barcode);
+          if (resultadoLocal) {
+            const producto = aProductoEscaneado(resultadoLocal);
+            queryClient.setQueryData(eanQueryKey(barcode), producto, {
+              updatedAt: Date.now(),
+            });
+            queryClient.setQueryDefaults(eanQueryKey(barcode), {
+              staleTime: EAN_STALE_TIME,
+            });
+            return { status: "found", producto };
+          }
+        }
         return { status: "error" };
       }
     },

--- a/src/lib/__tests__/catalogoLocal.test.ts
+++ b/src/lib/__tests__/catalogoLocal.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  buscarPorCodigoBarrasLocal,
+  buscarVariantesLocal,
+  obtenerMarcasYCategoriasLocal,
+  obtenerProductoPorVarianteIdLocal,
+  obtenerProductosPorVarianteIdsLocal,
+} from "@/lib/catalogoLocal";
+import { CatalogoCompleto } from "@/services/catalogo";
+import { ProductoBase, ProductoVariante } from "@/types";
+
+function base(overrides: Partial<ProductoBase> & { id: string; nombre: string }): ProductoBase {
+  return {
+    marca: undefined,
+    categoria: undefined,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+function variante(
+  overrides: Partial<ProductoVariante> & {
+    id: string;
+    productoBaseId: string;
+    codigoBarras: string;
+    nombreCompleto: string;
+  }
+): ProductoVariante {
+  return {
+    atributos: {},
+    createdAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+const bases: ProductoBase[] = [
+  base({ id: "base-1", nombre: "Leche", marca: "La Serenísima", categoria: "Lácteos" }),
+  base({ id: "base-2", nombre: "Yerba", marca: "Playadito", categoria: "Almacén" }),
+  base({ id: "base-3", nombre: "Nutriben", marca: "Alter", categoria: "Cereal Infantil" }),
+];
+
+const variantes: ProductoVariante[] = [
+  variante({ id: "v1", productoBaseId: "base-1", codigoBarras: "111", nombreCompleto: "Leche Entera 1L" }),
+  variante({ id: "v2", productoBaseId: "base-1", codigoBarras: "222", nombreCompleto: "Leche Descremada 1L" }),
+  variante({ id: "v3", productoBaseId: "base-2", codigoBarras: "333", nombreCompleto: "Con Palo 1kg" }),
+  variante({ id: "v4", productoBaseId: "base-3", codigoBarras: "444", nombreCompleto: "Trigo y Miel 400g" }),
+  // huérfana a propósito: apunta a una base que no existe en el catálogo
+  variante({ id: "v5", productoBaseId: "base-inexistente", codigoBarras: "555", nombreCompleto: "Fantasma" }),
+];
+
+const catalogo: CatalogoCompleto = {
+  bases,
+  variantes,
+  definiciones: { default: [], porCategoria: {} },
+};
+
+describe("buscarPorCodigoBarrasLocal", () => {
+  it("encuentra por EAN exacto", () => {
+    const resultado = buscarPorCodigoBarrasLocal(catalogo, "111");
+    expect(resultado?.base.nombre).toBe("Leche");
+    expect(resultado?.variante.nombreCompleto).toBe("Leche Entera 1L");
+  });
+
+  it("devuelve null si el EAN no existe", () => {
+    expect(buscarPorCodigoBarrasLocal(catalogo, "000")).toBeNull();
+  });
+
+  it("devuelve null si la variante existe pero su base no (huérfana)", () => {
+    expect(buscarPorCodigoBarrasLocal(catalogo, "555")).toBeNull();
+  });
+});
+
+describe("obtenerProductoPorVarianteIdLocal", () => {
+  it("encuentra por id de variante", () => {
+    expect(obtenerProductoPorVarianteIdLocal(catalogo, "v3")?.base.nombre).toBe("Yerba");
+  });
+
+  it("devuelve null si el id no existe", () => {
+    expect(obtenerProductoPorVarianteIdLocal(catalogo, "no-existe")).toBeNull();
+  });
+});
+
+describe("obtenerProductosPorVarianteIdsLocal", () => {
+  it("arma el índice deduplicando ids repetidos", () => {
+    const resultado = obtenerProductosPorVarianteIdsLocal(catalogo, ["v1", "v1", "v2"]);
+    expect(Object.keys(resultado).sort()).toEqual(["v1", "v2"]);
+  });
+
+  it("omite ids inexistentes en vez de incluir undefined", () => {
+    const resultado = obtenerProductosPorVarianteIdsLocal(catalogo, ["v1", "no-existe"]);
+    expect(Object.keys(resultado)).toEqual(["v1"]);
+  });
+
+  it("batch vacío devuelve objeto vacío sin iterar", () => {
+    expect(obtenerProductosPorVarianteIdsLocal(catalogo, [])).toEqual({});
+  });
+
+  it("omite variantes huérfanas (base inexistente)", () => {
+    const resultado = obtenerProductosPorVarianteIdsLocal(catalogo, ["v5"]);
+    expect(resultado).toEqual({});
+  });
+});
+
+describe("buscarVariantesLocal", () => {
+  it("término menor a 2 caracteres devuelve vacío", () => {
+    expect(buscarVariantesLocal(catalogo, "a")).toEqual([]);
+  });
+
+  it("matchea por nombreCompleto de la variante", () => {
+    const resultado = buscarVariantesLocal(catalogo, "descremada");
+    expect(resultado.map((p) => p.variante.id)).toEqual(["v2"]);
+  });
+
+  it("matchea por nombre de la base (aunque no aparezca en nombreCompleto)", () => {
+    const resultado = buscarVariantesLocal(catalogo, "nutriben");
+    expect(resultado.map((p) => p.variante.id)).toEqual(["v4"]);
+  });
+
+  it("matchea por marca de la base (aunque no aparezca en nombreCompleto)", () => {
+    const resultado = buscarVariantesLocal(catalogo, "playadito");
+    expect(resultado.map((p) => p.variante.id)).toEqual(["v3"]);
+  });
+
+  it("dedupe: una variante que matchea por nombreCompleto Y por base aparece una sola vez", () => {
+    // "leche" matchea nombreCompleto ("Leche Entera 1L"/"Leche Descremada 1L")
+    // Y el nombre de la base ("Leche") simultáneamente para v1 y v2.
+    const resultado = buscarVariantesLocal(catalogo, "leche");
+    expect(resultado.map((p) => p.variante.id).sort()).toEqual(["v1", "v2"]);
+  });
+
+  it("case-insensitive", () => {
+    const resultado = buscarVariantesLocal(catalogo, "LECHE");
+    expect(resultado.map((p) => p.variante.id).sort()).toEqual(["v1", "v2"]);
+  });
+
+  it("sanitiza comas sin dejar de matchear", () => {
+    const resultado = buscarVariantesLocal(catalogo, "leche,");
+    expect(resultado.map((p) => p.variante.id).sort()).toEqual(["v1", "v2"]);
+  });
+
+  it("ignora variantes huérfanas sin crashear", () => {
+    const resultado = buscarVariantesLocal(catalogo, "fantasma");
+    expect(resultado).toEqual([]);
+  });
+
+  it("corta en el límite de resultados", () => {
+    const muchasVariantes: ProductoVariante[] = Array.from({ length: 40 }, (_, i) =>
+      variante({
+        id: `bulk-${i}`,
+        productoBaseId: "base-1",
+        codigoBarras: `bulk-${i}`,
+        nombreCompleto: `Producto Bulk ${i}`,
+      })
+    );
+    const catalogoGrande: CatalogoCompleto = {
+      bases,
+      variantes: muchasVariantes,
+      definiciones: { default: [], porCategoria: {} },
+    };
+    const resultado = buscarVariantesLocal(catalogoGrande, "bulk");
+    expect(resultado.length).toBe(30);
+  });
+});
+
+describe("obtenerMarcasYCategoriasLocal", () => {
+  it("deduplica y ordena, excluyendo undefined", () => {
+    const catalogoConDuplicados: CatalogoCompleto = {
+      bases: [
+        ...bases,
+        base({ id: "base-4", nombre: "Otra Leche", marca: "La Serenísima", categoria: "Lácteos" }),
+        base({ id: "base-5", nombre: "Sin marca ni categoría" }),
+      ],
+      variantes,
+      definiciones: { default: [], porCategoria: {} },
+    };
+    const { marcas, categorias } = obtenerMarcasYCategoriasLocal(catalogoConDuplicados);
+    expect(marcas).toEqual(["Alter", "La Serenísima", "Playadito"]);
+    expect(categorias).toEqual(["Almacén", "Cereal Infantil", "Lácteos"]);
+  });
+});

--- a/src/lib/__tests__/queryPersister.test.ts
+++ b/src/lib/__tests__/queryPersister.test.ts
@@ -38,10 +38,10 @@ describe("deserializarConFechas", () => {
 });
 
 describe("esQueryPersistible", () => {
-  it("persiste las listas activas, el catálogo de items y los EAN resueltos", () => {
+  it("persiste las listas activas, el catálogo completo y los EAN resueltos", () => {
     expect(esQueryPersistible(["reposicion", "items"])).toBe(true);
     expect(esQueryPersistible(["vencimiento", "items"])).toBe(true);
-    expect(esQueryPersistible(["catalogo", "por-variante-ids", ["v1"]])).toBe(true);
+    expect(esQueryPersistible(["catalogo", "completo"])).toBe(true);
     expect(esQueryPersistible(["producto", "ean", "779..."])).toBe(true);
   });
 
@@ -49,5 +49,8 @@ describe("esQueryPersistible", () => {
     expect(esQueryPersistible(["reposicion", "historial"])).toBe(false);
     expect(esQueryPersistible(["vencimiento", "estadisticas", "mes"])).toBe(false);
     expect(esQueryPersistible(["marcas-categorias"])).toBe(false);
+    // Reemplazada por ["catalogo","completo"]: useProductosDeItems ya no
+    // dispara un useQuery propio, deriva del catálogo completo vía useMemo.
+    expect(esQueryPersistible(["catalogo", "por-variante-ids", ["v1"]])).toBe(false);
   });
 });

--- a/src/lib/catalogoLocal.ts
+++ b/src/lib/catalogoLocal.ts
@@ -1,0 +1,109 @@
+import { CatalogoCompleto, ProductoCompleto } from "@/services/catalogo";
+
+/**
+ * Lookups y búsquedas puras/síncronas sobre un catálogo ya cargado en
+ * memoria (ver useCatalogoCompleto). Reemplazan los round-trips a Supabase
+ * de catalogo.ts para el camino offline: mismos criterios de matching,
+ * cero red.
+ */
+
+function indexarBases(bases: CatalogoCompleto["bases"]) {
+  return new Map(bases.map((b) => [b.id, b]));
+}
+
+export function buscarPorCodigoBarrasLocal(
+  catalogo: CatalogoCompleto,
+  ean: string
+): ProductoCompleto | null {
+  const variante = catalogo.variantes.find((v) => v.codigoBarras === ean);
+  if (!variante) return null;
+  const base = indexarBases(catalogo.bases).get(variante.productoBaseId);
+  if (!base) return null;
+  return { base, variante };
+}
+
+export function obtenerProductoPorVarianteIdLocal(
+  catalogo: CatalogoCompleto,
+  varianteId: string
+): ProductoCompleto | null {
+  const variante = catalogo.variantes.find((v) => v.id === varianteId);
+  if (!variante) return null;
+  const base = indexarBases(catalogo.bases).get(variante.productoBaseId);
+  if (!base) return null;
+  return { base, variante };
+}
+
+export function obtenerProductosPorVarianteIdsLocal(
+  catalogo: CatalogoCompleto,
+  varianteIds: string[]
+): Record<string, ProductoCompleto> {
+  const idsUnicos = Array.from(new Set(varianteIds));
+  const basesPorId = indexarBases(catalogo.bases);
+  const variantesPorId = new Map(catalogo.variantes.map((v) => [v.id, v]));
+  const resultado: Record<string, ProductoCompleto> = {};
+  for (const id of idsUnicos) {
+    const variante = variantesPorId.get(id);
+    if (!variante) continue;
+    const base = basesPorId.get(variante.productoBaseId);
+    if (!base) continue;
+    resultado[id] = { base, variante };
+  }
+  return resultado;
+}
+
+/**
+ * Saca caracteres que en la búsqueda remota rompen el filtro `.or()` de
+ * PostgREST (ver catalogo.ts). Localmente no hay razón sintáctica para
+ * sanitizar, pero se mantiene para que "qué cuenta como match" no diverja
+ * entre la búsqueda online y la offline.
+ */
+function sanitizarTerminoBusqueda(termino: string): string {
+  return termino.replace(/[,%()]/g, "").trim();
+}
+
+const LIMITE_BUSQUEDA_LOCAL = 30;
+
+/**
+ * Reemplazo fiel de buscarVariantes (catalogo.ts): el original hace 2
+ * queries (ilike sobre nombre_completo, or sobre nombre/marca de la base)
+ * mergeadas con un Set para dedupe. Acá alcanza un solo pase por variante,
+ * ya visitada una única vez, sin Set.
+ */
+export function buscarVariantesLocal(
+  catalogo: CatalogoCompleto,
+  termino: string
+): ProductoCompleto[] {
+  const limpio = sanitizarTerminoBusqueda(termino).toLowerCase();
+  if (limpio.length < 2) return [];
+
+  const basesPorId = indexarBases(catalogo.bases);
+  const resultado: ProductoCompleto[] = [];
+
+  for (const variante of catalogo.variantes) {
+    const base = basesPorId.get(variante.productoBaseId);
+    if (!base) continue;
+
+    const matchVariante = variante.nombreCompleto.toLowerCase().includes(limpio);
+    const matchBase =
+      base.nombre.toLowerCase().includes(limpio) ||
+      (base.marca?.toLowerCase().includes(limpio) ?? false);
+
+    if (matchVariante || matchBase) {
+      resultado.push({ base, variante });
+      if (resultado.length >= LIMITE_BUSQUEDA_LOCAL) break;
+    }
+  }
+  return resultado;
+}
+
+export function obtenerMarcasYCategoriasLocal(
+  catalogo: CatalogoCompleto
+): { marcas: string[]; categorias: string[] } {
+  const marcas = Array.from(
+    new Set(catalogo.bases.map((b) => b.marca).filter((v): v is string => Boolean(v)))
+  ).sort();
+  const categorias = Array.from(
+    new Set(catalogo.bases.map((b) => b.categoria).filter((v): v is string => Boolean(v)))
+  ).sort();
+  return { marcas, categorias };
+}

--- a/src/lib/queryPersister.ts
+++ b/src/lib/queryPersister.ts
@@ -45,14 +45,15 @@ export function deserializarConFechas(cached: string) {
 
 /**
  * Se persisten solo las lecturas que el gondolero necesita en el pasillo
- * sin señal: las dos listas activas, el catálogo de sus items y los EAN
- * ya resueltos. Historial y estadísticas se consultan con calma y online.
+ * sin señal: las dos listas activas, el catálogo completo (bases +
+ * variantes + definiciones, ver useCatalogoCompleto) y los EAN ya
+ * resueltos. Historial y estadísticas se consultan con calma y online.
  */
 export function esQueryPersistible(queryKey: readonly unknown[]): boolean {
   return (
     (queryKey[0] === "reposicion" && queryKey[1] === "items") ||
     (queryKey[0] === "vencimiento" && queryKey[1] === "items") ||
-    (queryKey[0] === "catalogo" && queryKey[1] === "por-variante-ids") ||
+    (queryKey[0] === "catalogo" && queryKey[1] === "completo") ||
     (queryKey[0] === "producto" && queryKey[1] === "ean")
   );
 }

--- a/src/services/__tests__/catalogo.test.ts
+++ b/src/services/__tests__/catalogo.test.ts
@@ -260,6 +260,58 @@ describe("obtenerMarcasYCategorias", () => {
   });
 });
 
+describe("obtenerCatalogoCompleto", () => {
+  it("trae bases + variantes + definiciones en paralelo y las mapea", async () => {
+    const { obtenerCatalogoCompleto } = await import("@/services/catalogo");
+    fromMock.mockImplementation(
+      mockSupabaseFrom(
+        { data: [baseRow] }, // producto_bases
+        { data: [varianteRow] }, // producto_variantes
+        {
+          data: [
+            { categoria: null, clave: "tipo", etiqueta: "Tipo", orden: 0, sugerencias: [] },
+          ],
+        } // categoria_atributos (dentro de obtenerDefinicionesAtributos)
+      )
+    );
+
+    const catalogo = await obtenerCatalogoCompleto();
+
+    expect(catalogo.bases).toEqual([expect.objectContaining({ id: "base-1", nombre: "Leche" })]);
+    expect(catalogo.variantes).toEqual([
+      expect.objectContaining({ id: "variante-1", codigoBarras: "7791234567890" }),
+    ]);
+    expect(catalogo.definiciones.default.map((d) => d.clave)).toEqual(["tipo"]);
+    expect(fromMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("propaga el error si falla la consulta de bases", async () => {
+    const { obtenerCatalogoCompleto } = await import("@/services/catalogo");
+    fromMock.mockImplementation(
+      mockSupabaseFrom(
+        { error: new Error("bases caídas") },
+        { data: [] },
+        { data: [] }
+      )
+    );
+
+    await expect(obtenerCatalogoCompleto()).rejects.toThrow("bases caídas");
+  });
+
+  it("propaga el error si falla la consulta de variantes", async () => {
+    const { obtenerCatalogoCompleto } = await import("@/services/catalogo");
+    fromMock.mockImplementation(
+      mockSupabaseFrom(
+        { data: [] },
+        { error: new Error("variantes caídas") },
+        { data: [] }
+      )
+    );
+
+    await expect(obtenerCatalogoCompleto()).rejects.toThrow("variantes caídas");
+  });
+});
+
 describe("buscarProductos", () => {
   it("no consulta la base si el término sanitizado queda muy corto", async () => {
     const { buscarProductos } = await import("@/services/catalogo");

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -347,3 +347,33 @@ export async function obtenerMarcasYCategorias(): Promise<{
 
   return { marcas, categorias };
 }
+
+export interface CatalogoCompleto {
+  bases: ProductoBase[];
+  variantes: ProductoVariante[];
+  definiciones: DefinicionesAtributos;
+}
+
+/**
+ * Todo el catálogo (bases + variantes + definiciones de atributos) en un
+ * solo objeto: 110 bases / 402 variantes pesan ~164KB en JSON, trivial para
+ * cachear entero en IndexedDB. Es la fuente para lookup/búsqueda offline
+ * (ver src/lib/catalogoLocal.ts) — reemplaza N round-trips por 1 sync.
+ */
+export async function obtenerCatalogoCompleto(): Promise<CatalogoCompleto> {
+  const [basesResult, variantesResult, definiciones] = await Promise.all([
+    supabase.from("producto_bases").select("*"),
+    supabase.from("producto_variantes").select("*"),
+    obtenerDefinicionesAtributos(),
+  ]);
+  if (basesResult.error) throw basesResult.error;
+  if (variantesResult.error) throw variantesResult.error;
+
+  return {
+    bases: (basesResult.data ?? []).map((row) => mapProductoBase(row as ProductoBaseRow)),
+    variantes: (variantesResult.data ?? []).map((row) =>
+      mapProductoVariante(row as ProductoVarianteRow)
+    ),
+    definiciones,
+  };
+}


### PR DESCRIPTION
## 📝 Descripción

El catálogo (buscar por nombre, escanear un EAN, autocompletar marca/categoría/atributos) era 100% online-only: si el gondolero estaba en un pasillo sin señal, escanear un producto que sí existe fallaba con un toast pidiendo revisar la conexión. Las listas de reposición/vencimiento en cambio ya funcionan offline (outbox + persistencia en IndexedDB) — esta PR cierra esa brecha para el catálogo.

Se verificó que el catálogo completo (110 bases + 402 variantes + definiciones de `categoria_atributos`) pesa **164 KB en JSON** — trivial para cachear entero en IndexedDB en vez de resolver cada lookup contra Supabase.

**Arquitectura:**
- `useCatalogoCompleto()` (nuevo) trae las 3 tablas en una sola query persistida (`["catalogo","completo"]`), reemplazando varias queries dispersas por hook.
- `src/lib/catalogoLocal.ts` (nuevo) reproduce fielmente la lógica de búsqueda/lookup que antes vivía en `catalogo.ts`, como funciones puras y síncronas sobre el catálogo ya en memoria — testeable sin mocks de red.
- `useProductosDeItems`, `useBuscarVariantes` y `useMarcasCategorias` pasan a derivar del catálogo local vía `useMemo`, sin round-trip propio. Firma pública sin cambios — cero impacto en `ReposicionList`/`VencimientoList`/`ProductSearchSheet`/`ManualProductSheet`.
- `useScanProduct` (el lookup de mayor riesgo: un falso "no encontrado" dispara la creación de un duplicado) mantiene la red como camino primario **intacto** — mismo happy path online de siempre — y solo agrega un fallback al catálogo local dentro del `catch`. Prioriza exactitud online por sobre velocidad, a diferencia de búsqueda/autocompletado que sí pasan a ser 100% locales.
- `CatalogoSyncProvider` (nuevo) prefetchea el catálogo al montar la app y lo refresca en cada reconexión — mismo patrón que `OutboxProvider`, pero para una lectura en vez de la cola de mutaciones.
- El GET de `/api/productos/crear-manual` queda sin consumidores tras este cambio; se deja como red de recuperación con un comentario `TODO` explicando por qué.

**Alcance:** solo lectura. Crear un producto nuevo sigue necesitando red (el parseo con IA ya la requiere de todas formas) — no se tocó `crearProductoManual` ni el outbox de mutaciones.

## 🎯 Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 💥 Breaking change
- [ ] 📚 Documentación
- [ ] 🎨 Mejora de UI/UX
- [x] ⚡ Mejora de rendimiento (búsqueda/autocompletado pasan de round-trip a instantáneo)
- [x] ♻️ Refactorización (consolida 4 fuentes de datos de catálogo en una)

## 🔗 Issue relacionado

N/A — sale de la brecha entre "app offline-first" y el catálogo siendo online-only, identificada tras el trabajo de normalización del catálogo (PRs #86, #87, #90).

## 🧪 Testing

- [x] `npm run lint` sin errores
- [x] `npx vitest run`: 171 tests en verde (27 nuevos: `catalogoLocal.test.ts` completo, casos nuevos en `catalogo.test.ts` y `useScanProduct.test.tsx`)
- [x] `npm run build` OK
- [x] **Verificado en el navegador con `fetch` bloqueado hacia `supabase.co` y `navigator.onLine = false`**: buscar por nombre devolvió los mismos resultados offline que online; escanear un EAN real ya sincronizado (Milex Mini 2200g) lo encontró en el catálogo local y lo agregó a la lista de reposición — flujo completo end-to-end sin red, sincronizado por el outbox existente al reconectar. Dato de prueba limpiado de producción.
- [ ] Probado en Safari/Firefox
- [x] Funciona offline (PWA) — es el objetivo central de esta PR
- [x] Scanner de códigos de barras funcional (online y offline)

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] Auto-revisión realizada
- [x] Comentarios donde el porqué no es obvio (asimetría red-primero vs. local-primero, por qué el GET queda vivo)
- [x] Sin warnings nuevos
- [x] Los tests existentes pasan

## 🎯 Instrucciones de testing

1. Abrir la app con conexión y esperar unos segundos (el catálogo se prefetchea al montar vía `CatalogoSyncProvider`).
2. Simular offline (DevTools → Network → Offline, o desconectar wifi).
3. Buscar un producto existente por nombre — debe devolver resultados instantáneos.
4. Escanear (o ingresar manualmente) un código de barras de un producto ya existente — debe encontrarlo y permitir agregarlo a la lista, sin el toast de "revisá tu conexión".
5. Reconectar y confirmar que los cambios pendientes se sincronizan (badge de outbox baja a 0).

## 📌 Notas adicionales

Limitación conocida y aceptada: la rehidratación de `["catalogo","completo"]` desde IndexedDB requiere que una sesión anterior lo haya persistido con éxito — la app necesita haber estado online al menos una vez (mismo comportamiento que ya tienen reposición/vencimiento).

🤖 Generado con [Claude Code](https://claude.com/claude-code)