### PR TITLE
Mejoras al módulo de vencimiento: fechas en horario local, estadísticas en Postgres y UX

### DIFF
--- a/src/components/vencimiento/VencimientoEstadisticas.tsx
+++ b/src/components/vencimiento/VencimientoEstadisticas.tsx
@@ -33,7 +33,7 @@ export function VencimientoEstadisticas() {
       ) : (
         <>
           <div className="grid grid-cols-2 gap-3 mb-3">
-            <StatTile label="Productos retirados" value={stats.totalRetirados} />
+            <StatTile label="Unidades retiradas" value={stats.totalRetirados} />
             <StatTile
               label="Promedio días vs. vencimiento"
               value={

--- a/src/components/vencimiento/VencimientoItem.tsx
+++ b/src/components/vencimiento/VencimientoItem.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { calcularDiasRestantes, formatearFecha } from "@/lib/utils";
-import { useEliminarVencimientoItem, useRetirarVencimientoItem } from "@/hooks/useVencimiento";
+import {
+  useAgregarVencimientoItem,
+  useEliminarVencimientoItem,
+  useRetirarVencimientoItem,
+} from "@/hooks/useVencimiento";
 import { AlertaNivel, ItemVencimientoConAlerta, ProductoVariante } from "@/types";
 import { Calendar, Check, Edit2, PackageCheck, Trash2 } from "lucide-react";
 import { Badge, IconButton } from "../ui";
@@ -39,6 +43,7 @@ export function VencimientoItem({
 }: VencimientoItemProps) {
   const retirarItem = useRetirarVencimientoItem();
   const eliminarItem = useEliminarVencimientoItem();
+  const agregarItem = useAgregarVencimientoItem();
   const { haptic } = useHaptics();
   const diasRestantes = calcularDiasRestantes(item.fechaVencimiento);
 
@@ -64,8 +69,27 @@ export function VencimientoItem({
 
   const handleEliminar = () => {
     haptic([50, 100, 50]);
+    // Snapshot para el deshacer: el item sale del cache al confirmarse el borrado.
+    const { varianteId, fechaVencimiento, cantidad, lote } = item;
     eliminarItem.mutate(item.id, {
-      onSuccess: () => toast("Producto quitado de la lista", { icon: "🗑️" }),
+      onSuccess: () =>
+        toast(
+          (t) => (
+            <div className="flex items-center gap-3">
+              <span>Producto quitado de la lista</span>
+              <button
+                onClick={() => {
+                  toast.dismiss(t.id);
+                  agregarItem.mutate({ varianteId, fechaVencimiento, cantidad, lote });
+                }}
+                className="font-semibold text-accent whitespace-nowrap"
+              >
+                Deshacer
+              </button>
+            </div>
+          ),
+          { icon: "🗑️", duration: 5000 }
+        ),
     });
   };
 

--- a/src/components/vencimiento/VencimientoList.tsx
+++ b/src/components/vencimiento/VencimientoList.tsx
@@ -15,6 +15,7 @@ import {
   useVencimientoItems,
 } from "@/hooks/useVencimiento";
 import { useSeleccionMultiple } from "@/hooks/useSeleccionMultiple";
+import { sumarDias, toDateInputValue } from "@/lib/utils";
 import { AlertaNivel, ItemVencimientoConAlerta, ProductoVariante } from "@/types";
 import { motion as m } from "framer-motion";
 import {
@@ -47,6 +48,9 @@ const SECCIONES: Array<{
   { nivel: "precaucion", titulo: "Precaución (30-60 días)", icon: Zap, colorClass: "text-alert-precaucion" },
   { nivel: "normal", titulo: "Normales (+60 días)", icon: CheckCircle2, colorClass: "text-alert-normal" },
 ];
+
+// Mismos presets que ExpiryQuickSheet (registro desde el scanner).
+const PRESETS_DIAS = [7, 15, 30, 60, 90];
 
 const OPCIONES_ORDEN = [
   { value: "vencimiento", label: "Por vencer primero" },
@@ -120,14 +124,18 @@ export function VencimientoList() {
 
   const handleEditClick = (item: ItemVencimientoConAlerta) => {
     setEditingItem(item);
-    setNewDate(item.fechaVencimiento.toISOString().split("T")[0]);
+    // toDateInputValue serializa en horario local: con toISOString() el input
+    // mostraba el día anterior en husos UTC-.
+    setNewDate(toDateInputValue(item.fechaVencimiento));
   };
 
   const handleSaveDate = async () => {
     if (editingItem && newDate) {
       await actualizarFecha.mutateAsync({
         id: editingItem.id,
-        fechaVencimiento: new Date(newDate),
+        // T00:00:00 fuerza medianoche local; new Date("YYYY-MM-DD") sería
+        // medianoche UTC y desplazaba la fecha un día.
+        fechaVencimiento: new Date(`${newDate}T00:00:00`),
       });
       setEditingItem(null);
       setNewDate("");
@@ -276,6 +284,18 @@ export function VencimientoList() {
           <p className="text-subhead text-fg-secondary">
             Actualizá la fecha de vencimiento para este producto.
           </p>
+
+          <div className="flex flex-wrap gap-2">
+            {PRESETS_DIAS.map((dias) => (
+              <button
+                key={dias}
+                onClick={() => setNewDate(toDateInputValue(sumarDias(dias)))}
+                className="tap-compact px-3.5 rounded-chip text-subhead font-semibold bg-surface-2 text-fg-secondary transition-colors"
+              >
+                +{dias}d
+              </button>
+            ))}
+          </div>
 
           <Input
             type="date"

--- a/src/hooks/useVencimiento.tsx
+++ b/src/hooks/useVencimiento.tsx
@@ -3,7 +3,7 @@
 import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
 import { ejecutarMasivoOEncolar, ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
 import { crearTempId } from "@/lib/outbox/types";
-import { calcularNivelAlerta } from "@/lib/utils";
+import { calcularNivelAlerta, toDateInputValue } from "@/lib/utils";
 import * as vencimientoService from "@/services/vencimiento";
 import { ItemVencimientoConAlerta } from "@/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -59,7 +59,9 @@ export function useAgregarVencimientoItem() {
       await enqueueOperation("vencimiento.agregarItem", {
         tempId,
         varianteId,
-        fechaVencimiento: fechaVencimiento.toISOString().slice(0, 10),
+        // Serializar en horario local (no toISOString/UTC): la fecha es un
+        // DATE sin hora y el executor la re-parsea a medianoche local.
+        fechaVencimiento: toDateInputValue(fechaVencimiento),
         cantidad,
         lote,
       });
@@ -97,7 +99,7 @@ export function useActualizarFechaVencimiento() {
         () =>
           enqueueOperation("vencimiento.actualizarFecha", {
             id,
-            fechaVencimiento: fechaVencimiento.toISOString().slice(0, 10),
+            fechaVencimiento: toDateInputValue(fechaVencimiento),
           }),
         null as ItemVencimientoConAlerta | null
       ),

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -6,6 +6,8 @@ import {
   formatearFecha,
   generarUUID,
   ordenarClavesAtributos,
+  sumarDias,
+  toDateInputValue,
 } from "@/lib/utils";
 
 describe("construirNombreCompleto", () => {
@@ -115,6 +117,27 @@ describe("formatearFecha", () => {
     const resultado = formatearFecha(new Date("2026-03-15T00:00:00"));
     expect(resultado).toContain("2026");
     expect(resultado.toLowerCase()).toContain("marzo");
+  });
+});
+
+describe("toDateInputValue", () => {
+  it("serializa en horario local, no en UTC", () => {
+    expect(toDateInputValue(new Date(2026, 6, 7))).toBe("2026-07-07");
+  });
+
+  it("hace roundtrip con el parseo a medianoche local (convención del módulo)", () => {
+    // Invariante que rompía toISOString(): en husos UTC- la medianoche local
+    // cae en el día anterior en UTC y la fecha se corría un día.
+    const valor = "2026-03-15";
+    expect(toDateInputValue(new Date(`${valor}T00:00:00`))).toBe(valor);
+  });
+});
+
+describe("sumarDias", () => {
+  it("suma días sobre una base explícita, normalizada a medianoche", () => {
+    const resultado = sumarDias(7, new Date(2026, 0, 30, 15, 45));
+    expect(toDateInputValue(resultado)).toBe("2026-02-06");
+    expect(resultado.getHours()).toBe(0);
   });
 });
 

--- a/src/lib/outbox/executors.ts
+++ b/src/lib/outbox/executors.ts
@@ -44,7 +44,10 @@ export async function ejecutarOperacion(
     case "vencimiento.agregarItem": {
       const item = await vencimientoService.agregarItem(
         op.payload.varianteId,
-        new Date(op.payload.fechaVencimiento),
+        // El payload es YYYY-MM-DD en horario local; el sufijo T00:00:00
+        // fuerza el parseo a medianoche local (new Date("YYYY-MM-DD") solo
+        // sería medianoche UTC y correría la fecha un día en husos UTC-).
+        new Date(`${op.payload.fechaVencimiento}T00:00:00`),
         op.payload.cantidad,
         op.payload.lote
       );
@@ -53,7 +56,7 @@ export async function ejecutarOperacion(
     case "vencimiento.actualizarFecha":
       await vencimientoService.actualizarFecha(
         resolveId(op.payload.id),
-        new Date(op.payload.fechaVencimiento)
+        new Date(`${op.payload.fechaVencimiento}T00:00:00`)
       );
       return;
     case "vencimiento.actualizarCantidad":

--- a/src/services/__tests__/vencimiento.test.ts
+++ b/src/services/__tests__/vencimiento.test.ts
@@ -125,8 +125,45 @@ describe("retirarItemsMasivo", () => {
 });
 
 describe("obtenerEstadisticas", () => {
-  it("devuelve ceros cuando no hay retiros en el período", async () => {
+  it("agrega en Postgres vía la RPC obtener_estadisticas_vencimiento", async () => {
     const { obtenerEstadisticas } = await import("@/services/vencimiento");
+    rpcMock.mockResolvedValue({
+      data: {
+        total_retirados: 7,
+        promedio_dias_a_retiro: 1.5,
+        productos_mas_retirados: [{ producto_nombre: "Leche", cantidad: 5 }],
+      },
+      error: null,
+    });
+
+    const stats = await obtenerEstadisticas("mes");
+    expect(rpcMock).toHaveBeenCalledWith(
+      "obtener_estadisticas_vencimiento",
+      expect.objectContaining({ p_desde: expect.any(String), p_hasta: expect.any(String) })
+    );
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(stats.totalRetirados).toBe(7);
+    expect(stats.promedioDiasARetiro).toBe(1.5);
+    expect(stats.productosMasRetirados).toEqual([{ productoNombre: "Leche", cantidad: 5 }]);
+  });
+
+  it("propaga errores de la RPC que no sean de función inexistente", async () => {
+    const { obtenerEstadisticas } = await import("@/services/vencimiento");
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: Object.assign(new Error("boom"), { code: "XX000" }),
+    });
+
+    await expect(obtenerEstadisticas("mes")).rejects.toThrow("boom");
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("devuelve ceros cuando no hay retiros en el período (fallback client-side)", async () => {
+    const { obtenerEstadisticas } = await import("@/services/vencimiento");
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { code: "PGRST202", message: "function not found" },
+    });
     fromMock.mockImplementation(mockSupabaseFrom({ data: [] }));
 
     const stats = await obtenerEstadisticas("mes");
@@ -134,8 +171,12 @@ describe("obtenerEstadisticas", () => {
     expect(stats.promedioDiasARetiro).toBe(0);
   });
 
-  it("calcula el promedio de días entre vencimiento y retiro", async () => {
+  it("cae al cálculo client-side si la RPC aún no existe (PGRST202)", async () => {
     const { obtenerEstadisticas } = await import("@/services/vencimiento");
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { code: "PGRST202", message: "function not found" },
+    });
     fromMock.mockImplementation(
       mockSupabaseFrom({
         data: [
@@ -159,7 +200,8 @@ describe("obtenerEstadisticas", () => {
     );
 
     const stats = await obtenerEstadisticas("mes");
-    expect(stats.totalRetirados).toBe(1);
+    // Cuenta unidades (cantidad), no filas: misma semántica que el top de productos.
+    expect(stats.totalRetirados).toBe(2);
     expect(stats.promedioDiasARetiro).toBe(2); // retirado 2 días después de vencer
     expect(stats.productosMasRetirados[0]).toEqual({ productoNombre: "Leche", cantidad: 2 });
   });

--- a/src/services/vencimiento.ts
+++ b/src/services/vencimiento.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/lib/supabase";
-import { calcularNivelAlerta } from "@/lib/utils";
+import { calcularNivelAlerta, toDateInputValue } from "@/lib/utils";
 import {
   EstadisticasVencimiento,
   ItemVencimiento,
@@ -85,7 +85,9 @@ export async function agregarItem(
     .from("items_vencimiento")
     .insert({
       variante_id: varianteId,
-      fecha_vencimiento: fechaVencimiento.toISOString().slice(0, 10),
+      // toDateInputValue serializa en horario local: con toISOString() una
+      // fecha a medianoche local se corría un día en husos UTC+.
+      fecha_vencimiento: toDateInputValue(fechaVencimiento),
       cantidad: cantidad ?? null,
       lote: lote ?? null,
       estado: "pendiente",
@@ -102,7 +104,7 @@ export async function actualizarFecha(
 ): Promise<ItemVencimientoConAlerta> {
   const { data, error } = await supabase
     .from("items_vencimiento")
-    .update({ fecha_vencimiento: fechaVencimiento.toISOString().slice(0, 10) })
+    .update({ fecha_vencimiento: toDateInputValue(fechaVencimiento) })
     .eq("id", id)
     .select()
     .single();
@@ -180,6 +182,20 @@ export async function obtenerHistorial(filtros?: {
   return (data ?? []).map((row) => mapHistorial(row as ItemVencimientoHistorialRow));
 }
 
+interface EstadisticasRpcResult {
+  total_retirados: number;
+  promedio_dias_a_retiro: number;
+  productos_mas_retirados: Array<{ producto_nombre: string; cantidad: number }>;
+}
+
+/**
+ * Estadísticas de retiros del período. Agrega en Postgres
+ * (`obtener_estadisticas_vencimiento`, migración 0011): antes bajaba todo el
+ * historial del período y agregaba en JS, con el cap implícito de 1000 filas
+ * de PostgREST que silenciosamente recortaba períodos largos.
+ * `totalRetirados` cuenta unidades (cantidad, o 1 si no se registró), igual
+ * que el top de productos.
+ */
 export async function obtenerEstadisticas(
   periodo: "semana" | "mes" | "año"
 ): Promise<EstadisticasVencimiento> {
@@ -197,7 +213,36 @@ export async function obtenerEstadisticas(
       break;
   }
 
-  const retirados = await obtenerHistorial({ desde: fechaInicio, hasta: ahora });
+  const { data, error } = await supabase.rpc("obtener_estadisticas_vencimiento", {
+    p_desde: fechaInicio.toISOString(),
+    p_hasta: ahora.toISOString(),
+  });
+
+  if (!error) {
+    const stats = data as EstadisticasRpcResult;
+    return {
+      periodo,
+      totalRetirados: stats.total_retirados,
+      promedioDiasARetiro: Number(stats.promedio_dias_a_retiro),
+      productosMasRetirados: (stats.productos_mas_retirados ?? []).map((p) => ({
+        productoNombre: p.producto_nombre,
+        cantidad: p.cantidad,
+      })),
+    };
+  }
+
+  // PGRST202: la RPC todavía no existe (migración 0011 sin aplicar).
+  // Fallback al cálculo client-side para no depender del orden de deploy.
+  if (error.code !== "PGRST202") throw error;
+  return obtenerEstadisticasClientSide(periodo, fechaInicio, ahora);
+}
+
+async function obtenerEstadisticasClientSide(
+  periodo: "semana" | "mes" | "año",
+  desde: Date,
+  hasta: Date
+): Promise<EstadisticasVencimiento> {
+  const retirados = await obtenerHistorial({ desde, hasta });
 
   if (retirados.length === 0) {
     return {
@@ -209,10 +254,13 @@ export async function obtenerEstadisticas(
   }
 
   const productosCount = new Map<string, number>();
+  let totalUnidades = 0;
   let sumaDias = 0;
   retirados.forEach((item) => {
+    const unidades = item.cantidad ?? 1;
+    totalUnidades += unidades;
     const count = productosCount.get(item.productoNombre) || 0;
-    productosCount.set(item.productoNombre, count + (item.cantidad ?? 1));
+    productosCount.set(item.productoNombre, count + unidades);
 
     const dias = Math.floor(
       (item.fechaRetiro.getTime() - item.fechaVencimiento.getTime()) / (1000 * 60 * 60 * 24)
@@ -227,7 +275,7 @@ export async function obtenerEstadisticas(
 
   return {
     periodo,
-    totalRetirados: retirados.length,
+    totalRetirados: totalUnidades,
     productosMasRetirados,
     promedioDiasARetiro: sumaDias / retirados.length,
   };

--- a/supabase/migrations/0011_estadisticas_vencimiento.sql
+++ b/supabase/migrations/0011_estadisticas_vencimiento.sql
@@ -1,0 +1,46 @@
+-- obtener_estadisticas_vencimiento: agrega las estadísticas de retiros en
+-- Postgres en vez del cliente.
+--
+-- Antes obtenerEstadisticas() bajaba todo el historial del período y agregaba
+-- en JS: lento para "año" y silenciosamente incorrecto pasadas las 1000 filas
+-- (cap implícito de PostgREST). Además el total contaba filas mientras el top
+-- de productos sumaba cantidades — acá ambos cuentan unidades (cantidad, o 1
+-- si no se registró).
+
+create or replace function obtener_estadisticas_vencimiento(
+  p_desde timestamptz,
+  p_hasta timestamptz
+)
+returns json
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with retirados as (
+    select
+      producto_nombre,
+      coalesce(cantidad, 1) as unidades,
+      (fecha_retiro::date - fecha_vencimiento) as dias_a_retiro
+    from items_vencimiento_historial
+    where fecha_retiro >= p_desde
+      and fecha_retiro <= p_hasta
+  )
+  select json_build_object(
+    'total_retirados', coalesce((select sum(unidades) from retirados), 0)::int,
+    'promedio_dias_a_retiro', coalesce((select avg(dias_a_retiro) from retirados), 0),
+    'productos_mas_retirados', coalesce(
+      (
+        select json_agg(t)
+        from (
+          select producto_nombre, sum(unidades)::int as cantidad
+          from retirados
+          group by producto_nombre
+          order by cantidad desc
+          limit 10
+        ) t
+      ),
+      '[]'::json
+    )
+  );
+$$;


### PR DESCRIPTION
## 📝 Descripción

Primera tanda de mejoras al módulo de vencimiento, en tres frentes:

**1. Bug de timezone en fechas (corrimiento de un día)**
El módulo mezclaba dos convenciones: serializaba fechas con `toISOString().slice(0, 10)` (UTC) pero las parseaba/mostraba en horario local. En husos UTC- (ej. Argentina) editar una fecha la mostraba corrida un día; en husos UTC+ se guardaba el día anterior. Ahora **toda** la serialización usa `toDateInputValue()` (horario local) y todo parseo de `YYYY-MM-DD` fuerza medianoche local (`new Date(\`${s}T00:00:00\`)`):
- `src/services/vencimiento.ts` (`agregarItem`, `actualizarFecha`)
- `src/hooks/useVencimiento.tsx` (payloads del outbox)
- `src/lib/outbox/executors.ts` (re-parseo al drenar la cola)
- `VencimientoList.tsx` (sheet de editar fecha, que además parseaba con `new Date("YYYY-MM-DD")` = medianoche UTC)

**2. Estadísticas agregadas en Postgres**
`obtenerEstadisticas()` bajaba todo el historial del período y agregaba en JS: lento para "año" y silenciosamente incorrecto pasadas las 1000 filas (cap implícito de PostgREST). Nueva RPC `obtener_estadisticas_vencimiento` (migración 0011) que agrega en SQL, con fallback client-side vía `PGRST202` si la migración aún no está aplicada (mismo patrón que `retirar_items_vencimiento`). Además unifica la semántica: antes el total contaba filas y el top de productos sumaba cantidades; ahora ambos cuentan unidades (`cantidad`, o 1 si no se registró).

**3. UX**
- El sheet de editar fecha ahora tiene los mismos presets `+7/15/30/60/90` días que el registro desde el scanner (`ExpiryQuickSheet`).
- Quitar un item de la lista (botón basura) ahora ofrece **Deshacer** en el toast durante 5s: re-agrega el item con los mismos datos (variante, fecha, cantidad, lote), compatible offline vía outbox.

## 🎯 Tipo de cambio

- [x] 🐛 Bug fix (cambio que corrige un problema)
- [ ] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [ ] 💥 Breaking change (cambio que rompe compatibilidad)
- [ ] 📚 Documentación
- [x] 🎨 Mejora de UI/UX
- [x] ⚡ Mejora de rendimiento
- [ ] ♻️ Refactorización

## 🔗 Issue relacionado

N/A

## 🧪 Testing

- [x] Los 157 tests pasan (`vitest run`), incluidos 6 nuevos
- [x] Tests de fechas verificados bajo `TZ=America/Argentina/Buenos_Aires` (UTC-3) y `TZ=Pacific/Auckland` (UTC+12)
- [x] `next build` en verde, lint sin errores nuevos, `tsc --noEmit` limpio
- [ ] Probado en móvil
- [ ] Funciona offline (PWA) — el flujo offline usa los mismos helpers testeados, falta prueba manual

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado el código en áreas difíciles de entender
- [x] Mis cambios no generan warnings nuevos
- [x] He actualizado la documentación correspondiente (comentarios en código y migración)
- [x] Los tests existentes pasan correctamente

## 📸 Screenshots (si aplica)

N/A (cambios visuales menores: chips de presets en el sheet de edición y botón Deshacer en el toast).

## 🎯 Instrucciones de testing

1. Aplicar la migración `supabase/migrations/0011_estadisticas_vencimiento.sql` en el proyecto Supabase.
2. Registrar un vencimiento desde el scanner, editarlo desde la lista con un preset `+30d` y verificar que la fecha mostrada coincide exactamente (sin corrimiento de un día).
3. Quitar un item con el botón basura y tocar "Deshacer" en el toast: el item debe reaparecer con la misma fecha, cantidad y lote.
4. En Historial, verificar que "Unidades retiradas" suma cantidades (retirar un item con cantidad 5 debe sumar 5, no 1).

## 📌 Notas adicionales

- El fallback client-side de estadísticas permite deployar el front antes de aplicar la migración 0011 (mismo criterio que el fallback de `retirarItemsMasivo`). Se puede borrar cuando 0011 esté en prod.
- Quedan pendientes (para PRs separados, por orden de valor): notificaciones/badge cuando un producto pasa a crítico, retiro parcial de unidades, detección de duplicados al escanear, y endurecer las políticas RLS `allow_all_anon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7C5X7S3Vesi6RW1pWL3eE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7C5X7S3Vesi6RW1pWL3eE)_