### PR TITLE
Notificaciones de vencimientos urgentes: badge en tab e ícono + alertas locales

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,9 @@ import { CollapsingHeader } from "@/components/shell/CollapsingHeader";
 import { TabBar } from "@/components/shell/TabBar";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { ReposicionList } from "@/components/reposicion/ReposicionList";
+import { NotificacionesBell } from "@/components/vencimiento/NotificacionesBell";
 import { VencimientoList } from "@/components/vencimiento/VencimientoList";
+import { useNotificacionesVencimiento } from "@/hooks/useNotificacionesVencimiento";
 import { springGentle } from "@/lib/motion";
 import { ActiveView, useUiStore } from "@/store/ui";
 import { AnimatePresence, motion as m } from "framer-motion";
@@ -45,6 +47,8 @@ function HomePageContent() {
   const { activeView, setActiveView, scannerOpen, openScanner, closeScanner } =
     useUiStore();
   const [searchOpen, setSearchOpen] = useState(false);
+  // Badge del ícono/tab + notificaciones locales de items urgentes.
+  const { urgentesCount } = useNotificacionesVencimiento();
 
   // Manejar URL params (shortcuts PWA y deep links)
   useEffect(() => {
@@ -85,6 +89,7 @@ function HomePageContent() {
             scrollContainerRef={scrollRef}
             rightActions={
               <>
+                {activeView === "vencimiento" && <NotificacionesBell />}
                 <Link
                   href={`/${activeView}/historial`}
                   aria-label="Ver historial"
@@ -112,6 +117,7 @@ function HomePageContent() {
             active={activeView}
             onChange={handleViewChange}
             onScan={openScanner}
+            badgeVencimientos={urgentesCount}
           />
         }
       >

--- a/src/components/shell/TabBar.tsx
+++ b/src/components/shell/TabBar.tsx
@@ -11,6 +11,8 @@ export interface TabBarProps {
   onChange: (view: ActiveView) => void;
   /** Botón central prominente; escanea en el modo de la vista activa. */
   onScan: () => void;
+  /** Cantidad de items urgentes (vencidos o críticos): burbuja en el tab. */
+  badgeVencimientos?: number;
 }
 
 const esCampoDeTexto = (el: EventTarget | null): boolean =>
@@ -24,7 +26,7 @@ const esCampoDeTexto = (el: EventTarget | null): boolean =>
  * Se esconde mientras un campo de texto tiene foco para no chocar con el
  * teclado en iOS Safari (position:fixed salta con el teclado abierto).
  */
-export function TabBar({ active, onChange, onScan }: TabBarProps) {
+export function TabBar({ active, onChange, onScan, badgeVencimientos = 0 }: TabBarProps) {
   const [oculta, setOculta] = useState(false);
 
   useEffect(() => {
@@ -74,6 +76,7 @@ export function TabBar({ active, onChange, onScan }: TabBarProps) {
           icon={<Clock size={22} />}
           activo={active === "vencimiento"}
           onClick={() => onChange("vencimiento")}
+          badge={badgeVencimientos}
         />
       </div>
     </m.nav>
@@ -85,11 +88,13 @@ function TabItem({
   icon,
   activo,
   onClick,
+  badge = 0,
 }: {
   label: string;
   icon: React.ReactNode;
   activo: boolean;
   onClick: () => void;
+  badge?: number;
 }) {
   return (
     <button
@@ -111,6 +116,14 @@ function TabItem({
         }`}
       >
         {icon}
+        {badge > 0 && (
+          <span
+            aria-label={`${badge} productos urgentes`}
+            className="absolute -top-1.5 -right-2.5 min-w-[18px] h-[18px] px-1 rounded-full bg-alert-critico text-white text-[11px] font-bold leading-none flex items-center justify-center tabular-nums"
+          >
+            {badge > 99 ? "99+" : badge}
+          </span>
+        )}
       </span>
       <span
         className={`relative text-caption font-semibold transition-colors ${

--- a/src/components/vencimiento/NotificacionesBell.tsx
+++ b/src/components/vencimiento/NotificacionesBell.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { solicitarPermiso, soportaNotificaciones } from "@/lib/notificacionesVencimiento";
+import { useNotificacionesStore } from "@/store/notificaciones";
+import { Bell, BellOff } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "react-hot-toast";
+
+/**
+ * Toggle de notificaciones de vencimientos urgentes. Pide el permiso del
+ * navegador la primera vez; después alterna la preferencia local sin tocar
+ * los permisos del sitio.
+ */
+export function NotificacionesBell() {
+  const { habilitadas, setHabilitadas } = useNotificacionesStore();
+  // Detectar soporte en un efecto (no en render) para no romper la
+  // hidratación: el server no tiene window.Notification.
+  const [soportadas, setSoportadas] = useState(false);
+  useEffect(() => {
+    setSoportadas(soportaNotificaciones());
+  }, []);
+
+  if (!soportadas) return null;
+
+  const handleClick = async () => {
+    if (habilitadas) {
+      setHabilitadas(false);
+      toast("Notificaciones desactivadas", { icon: "🔕" });
+      return;
+    }
+    const permiso = await solicitarPermiso();
+    if (permiso === "granted") {
+      setHabilitadas(true);
+      toast.success("Te avisamos cuando un producto esté por vencer");
+    } else {
+      toast.error(
+        "Permiso bloqueado: activá las notificaciones de GondolApp en los ajustes del navegador"
+      );
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={
+        habilitadas
+          ? "Desactivar notificaciones de vencimientos"
+          : "Activar notificaciones de vencimientos"
+      }
+      aria-pressed={habilitadas}
+      className={`w-11 h-11 flex items-center justify-center rounded-full transition-colors hover:bg-surface-2 ${
+        habilitadas ? "text-accent" : "text-fg-secondary"
+      }`}
+    >
+      {habilitadas ? <Bell size={22} /> : <BellOff size={22} />}
+    </button>
+  );
+}

--- a/src/components/vencimiento/VencimientoItem.tsx
+++ b/src/components/vencimiento/VencimientoItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { calcularDiasRestantes, formatearFecha } from "@/lib/utils";
+import { formatearFecha, mensajeVencimiento } from "@/lib/utils";
 import {
   useAgregarVencimientoItem,
   useEliminarVencimientoItem,
@@ -45,19 +45,6 @@ export function VencimientoItem({
   const eliminarItem = useEliminarVencimientoItem();
   const agregarItem = useAgregarVencimientoItem();
   const { haptic } = useHaptics();
-  const diasRestantes = calcularDiasRestantes(item.fechaVencimiento);
-
-  const getMensajeVencimiento = () => {
-    if (diasRestantes < 0) {
-      return `Venció hace ${Math.abs(diasRestantes)} días`;
-    } else if (diasRestantes === 0) {
-      return "¡Vence hoy!";
-    } else if (diasRestantes === 1) {
-      return "Vence mañana";
-    } else {
-      return `Vence en ${diasRestantes} días`;
-    }
-  };
 
   const handleRetirar = () => {
     haptic([30, 30, 30]);
@@ -118,7 +105,7 @@ export function VencimientoItem({
 
         <div className="space-y-2">
           <Badge alert={item.alertaNivel} className="text-subhead">
-            {getMensajeVencimiento()}
+            {mensajeVencimiento(item.fechaVencimiento)}
           </Badge>
 
           <div className="flex items-center flex-wrap gap-x-3 gap-y-1.5 text-footnote text-fg-secondary">

--- a/src/hooks/useNotificacionesVencimiento.ts
+++ b/src/hooks/useNotificacionesVencimiento.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  actualizarAppBadge,
+  esUrgente,
+  guardarNotificados,
+  ItemNotificable,
+  leerNotificados,
+  mostrarNotificacionVencimientos,
+  podarNotificados,
+  seleccionarItemsANotificar,
+  tienePermiso,
+} from "@/lib/notificacionesVencimiento";
+import { useNotificacionesStore } from "@/store/notificaciones";
+import { useEffect, useMemo } from "react";
+import { useProductosDeItems } from "./useProductosDeItems";
+import { useVencimientoItems } from "./useVencimiento";
+
+/**
+ * Mantiene el badge del ícono de la app y dispara notificaciones locales
+ * cuando un item entra en nivel urgente (crítico o vencido). Montarlo una
+ * sola vez donde viva la lista (HomePage); expone el contador de urgentes
+ * para el badge del tab.
+ */
+export function useNotificacionesVencimiento() {
+  const { data: items = [] } = useVencimientoItems();
+  const { data: productosPorVariante } = useProductosDeItems(
+    items.map((i) => i.varianteId)
+  );
+  const habilitadas = useNotificacionesStore((s) => s.habilitadas);
+
+  const urgentes = useMemo(
+    () => items.filter((item) => esUrgente(item.alertaNivel)),
+    [items]
+  );
+
+  useEffect(() => {
+    actualizarAppBadge(urgentes.length);
+  }, [urgentes.length]);
+
+  useEffect(() => {
+    if (!habilitadas || !tienePermiso()) return;
+    // Esperar los nombres del catálogo: notificar "Producto" no sirve de nada.
+    if (urgentes.length > 0 && !productosPorVariante) return;
+
+    const notificables: ItemNotificable[] = urgentes.map((item) => ({
+      id: item.id,
+      nombre:
+        productosPorVariante?.[item.varianteId]?.variante.nombreCompleto ??
+        "Producto",
+      alertaNivel: item.alertaNivel,
+      fechaVencimiento: item.fechaVencimiento,
+    }));
+
+    const registro = leerNotificados();
+    const nuevos = seleccionarItemsANotificar(notificables, registro);
+    if (nuevos.length > 0) {
+      void mostrarNotificacionVencimientos(nuevos);
+    }
+    const actualizado = podarNotificados(
+      {
+        ...registro,
+        ...Object.fromEntries(nuevos.map((item) => [item.id, item.alertaNivel])),
+      },
+      notificables
+    );
+    guardarNotificados(actualizado);
+  }, [urgentes, productosPorVariante, habilitadas]);
+
+  return { urgentesCount: urgentes.length };
+}

--- a/src/lib/__tests__/notificacionesVencimiento.test.ts
+++ b/src/lib/__tests__/notificacionesVencimiento.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  construirMensaje,
+  esUrgente,
+  ItemNotificable,
+  podarNotificados,
+  seleccionarItemsANotificar,
+} from "@/lib/notificacionesVencimiento";
+import { AlertaNivel } from "@/types";
+
+function diasDesdeHoy(dias: number): Date {
+  const fecha = new Date();
+  fecha.setHours(0, 0, 0, 0);
+  fecha.setDate(fecha.getDate() + dias);
+  return fecha;
+}
+
+function item(
+  id: string,
+  alertaNivel: AlertaNivel,
+  diasRestantes = 0,
+  nombre = `Producto ${id}`
+): ItemNotificable {
+  return { id, nombre, alertaNivel, fechaVencimiento: diasDesdeHoy(diasRestantes) };
+}
+
+describe("esUrgente", () => {
+  it("solo vencido y crítico son urgentes", () => {
+    expect(esUrgente("vencido")).toBe(true);
+    expect(esUrgente("critico")).toBe(true);
+    expect(esUrgente("advertencia")).toBe(false);
+    expect(esUrgente("precaucion")).toBe(false);
+    expect(esUrgente("normal")).toBe(false);
+  });
+});
+
+describe("seleccionarItemsANotificar", () => {
+  it("incluye urgentes nuevos y excluye niveles no urgentes", () => {
+    const items = [item("a", "critico", 5), item("b", "advertencia", 20)];
+    expect(seleccionarItemsANotificar(items, {})).toEqual([items[0]]);
+  });
+
+  it("no repite un item ya notificado en el mismo nivel", () => {
+    const items = [item("a", "critico", 5)];
+    expect(seleccionarItemsANotificar(items, { a: "critico" })).toEqual([]);
+  });
+
+  it("vuelve a notificar cuando un crítico pasa a vencido", () => {
+    const items = [item("a", "vencido", -1)];
+    expect(seleccionarItemsANotificar(items, { a: "critico" })).toEqual(items);
+  });
+});
+
+describe("podarNotificados", () => {
+  it("elimina del registro los items que ya no están urgentes", () => {
+    const items = [item("a", "critico", 5), item("c", "normal", 90)];
+    // "b" fue retirado y "c" corrigió su fecha: ambos salen del registro.
+    expect(podarNotificados({ a: "critico", b: "vencido", c: "critico" }, items)).toEqual({
+      a: "critico",
+    });
+  });
+});
+
+describe("construirMensaje", () => {
+  it("para un solo item usa el nombre como título y la urgencia en el cuerpo", () => {
+    const { titulo, cuerpo } = construirMensaje([
+      item("a", "critico", 0, "Leche Entera 1L"),
+    ]);
+    expect(titulo).toBe("Leche Entera 1L");
+    expect(cuerpo).toContain("¡Vence hoy!");
+  });
+
+  it("para varios items resume la cantidad y lista los nombres", () => {
+    const { titulo, cuerpo } = construirMensaje([
+      item("a", "vencido", -1, "Leche"),
+      item("b", "critico", 2, "Yogur"),
+    ]);
+    expect(titulo).toBe("2 productos urgentes por vencimiento");
+    expect(cuerpo).toBe("Leche, Yogur");
+  });
+
+  it("con más de 4 items corta la lista y agrega el resto como contador", () => {
+    const items = ["A", "B", "C", "D", "E", "F"].map((nombre, i) =>
+      item(String(i), "critico", 1, nombre)
+    );
+    const { cuerpo } = construirMensaje(items);
+    expect(cuerpo).toBe("A, B, C, D y 2 más");
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   construirNombreCompleto,
   formatearFecha,
   generarUUID,
+  mensajeVencimiento,
   ordenarClavesAtributos,
   sumarDias,
   toDateInputValue,
@@ -117,6 +118,16 @@ describe("formatearFecha", () => {
     const resultado = formatearFecha(new Date("2026-03-15T00:00:00"));
     expect(resultado).toContain("2026");
     expect(resultado.toLowerCase()).toContain("marzo");
+  });
+});
+
+describe("mensajeVencimiento", () => {
+  it("cubre hoy, mañana, futuro y pasado con plurales correctos", () => {
+    expect(mensajeVencimiento(diasDesdeHoy(0))).toBe("¡Vence hoy!");
+    expect(mensajeVencimiento(diasDesdeHoy(1))).toBe("Vence mañana");
+    expect(mensajeVencimiento(diasDesdeHoy(5))).toBe("Vence en 5 días");
+    expect(mensajeVencimiento(diasDesdeHoy(-1))).toBe("Venció hace 1 día");
+    expect(mensajeVencimiento(diasDesdeHoy(-3))).toBe("Venció hace 3 días");
   });
 });
 

--- a/src/lib/notificacionesVencimiento.ts
+++ b/src/lib/notificacionesVencimiento.ts
@@ -1,0 +1,159 @@
+import { mensajeVencimiento } from "@/lib/utils";
+import { AlertaNivel } from "@/types";
+
+/**
+ * Notificaciones locales de vencimientos urgentes.
+ *
+ * Sin backend de push: se dispara desde la app (abierta o instalada como PWA)
+ * cuando un item entra en nivel urgente. El registro de "ya notificado" vive
+ * en localStorage para no repetir la misma alerta en cada refetch; pasar de
+ * crítico a vencido cuenta como alerta nueva.
+ */
+
+const STORAGE_KEY = "gondolapp-vencimientos-notificados";
+
+/** URL que abre el service worker al tocar la notificación (ver sw.js). */
+const URL_VENCIMIENTOS = "/?view=vencimiento";
+
+export interface ItemNotificable {
+  id: string;
+  nombre: string;
+  alertaNivel: AlertaNivel;
+  fechaVencimiento: Date;
+}
+
+/** Map itemId → nivel por el que ya se notificó. */
+export type RegistroNotificados = Record<string, string>;
+
+export function esUrgente(nivel: AlertaNivel): boolean {
+  return nivel === "vencido" || nivel === "critico";
+}
+
+/**
+ * Items urgentes que todavía no se notificaron en su nivel actual.
+ * Un item notificado como crítico que pasa a vencido vuelve a salir.
+ */
+export function seleccionarItemsANotificar(
+  items: ItemNotificable[],
+  notificados: RegistroNotificados
+): ItemNotificable[] {
+  return items.filter(
+    (item) => esUrgente(item.alertaNivel) && notificados[item.id] !== item.alertaNivel
+  );
+}
+
+/**
+ * Depura el registro: conserva solo los items que siguen urgentes. Los
+ * retirados/eliminados (o con fecha corregida) salen, así pueden volver a
+ * notificar si algún día re-entran en urgencia.
+ */
+export function podarNotificados(
+  notificados: RegistroNotificados,
+  items: ItemNotificable[]
+): RegistroNotificados {
+  const urgentesActuales = new Set(
+    items.filter((item) => esUrgente(item.alertaNivel)).map((item) => item.id)
+  );
+  return Object.fromEntries(
+    Object.entries(notificados).filter(([id]) => urgentesActuales.has(id))
+  );
+}
+
+/** Arma título y cuerpo de la notificación para uno o varios items. */
+export function construirMensaje(items: ItemNotificable[]): {
+  titulo: string;
+  cuerpo: string;
+} {
+  if (items.length === 1) {
+    const item = items[0];
+    return {
+      titulo: item.nombre,
+      cuerpo: `${mensajeVencimiento(item.fechaVencimiento)} — revisá la góndola.`,
+    };
+  }
+  const nombres = items.map((item) => item.nombre);
+  const visibles = nombres.slice(0, 4);
+  const resto = nombres.length - visibles.length;
+  return {
+    titulo: `${items.length} productos urgentes por vencimiento`,
+    cuerpo: resto > 0 ? `${visibles.join(", ")} y ${resto} más` : visibles.join(", "),
+  };
+}
+
+export function leerNotificados(): RegistroNotificados {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}");
+  } catch {
+    return {};
+  }
+}
+
+export function guardarNotificados(registro: RegistroNotificados): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(registro));
+  } catch {
+    // Almacenamiento lleno o bloqueado: se reintenta en el próximo ciclo.
+  }
+}
+
+/** iOS Safari solo expone Notification con la PWA instalada (16.4+). */
+export function soportaNotificaciones(): boolean {
+  return typeof window !== "undefined" && "Notification" in window;
+}
+
+export function tienePermiso(): boolean {
+  return soportaNotificaciones() && Notification.permission === "granted";
+}
+
+export async function solicitarPermiso(): Promise<NotificationPermission> {
+  if (!soportaNotificaciones()) return "denied";
+  if (Notification.permission !== "default") return Notification.permission;
+  return Notification.requestPermission();
+}
+
+/**
+ * Muestra la notificación vía service worker (necesario en Android; permite
+ * que el tap abra la vista de vencimientos aunque la app esté cerrada) con
+ * fallback a Notification directa en desktop sin SW activo.
+ */
+export async function mostrarNotificacionVencimientos(
+  items: ItemNotificable[]
+): Promise<void> {
+  if (!tienePermiso() || items.length === 0) return;
+  const { titulo, cuerpo } = construirMensaje(items);
+  const opciones: NotificationOptions = {
+    body: cuerpo,
+    icon: "/icon-192x192.png",
+    badge: "/icon-calendar-96x96.png",
+    // Un solo aviso vivo: la alerta nueva reemplaza a la anterior.
+    tag: "vencimientos-urgentes",
+    data: { url: URL_VENCIMIENTOS },
+  };
+  try {
+    const registration = await navigator.serviceWorker?.getRegistration();
+    if (registration) {
+      await registration.showNotification(titulo, opciones);
+      return;
+    }
+  } catch {
+    // Sin SW registrado (dev, o navegador sin soporte): probar directo.
+  }
+  try {
+    new Notification(titulo, opciones);
+  } catch {
+    // Android exige SW para notificar; sin él no hay nada que hacer.
+  }
+}
+
+/** Contador en el ícono de la app instalada (Badging API, si existe). */
+export function actualizarAppBadge(count: number): void {
+  if (typeof navigator === "undefined") return;
+  const nav = navigator as Navigator & {
+    setAppBadge?: (contents?: number) => Promise<void>;
+    clearAppBadge?: () => Promise<void>;
+  };
+  if (count > 0) nav.setAppBadge?.(count).catch(() => {});
+  else nav.clearAppBadge?.().catch(() => {});
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -89,6 +89,18 @@ export function calcularDiasRestantes(fechaVencimiento: Date): number {
   );
 }
 
+/** Mensaje corto de urgencia: "Venció hace 3 días", "¡Vence hoy!", "Vence en 5 días". */
+export function mensajeVencimiento(fechaVencimiento: Date): string {
+  const dias = calcularDiasRestantes(fechaVencimiento);
+  if (dias < 0) {
+    const abs = Math.abs(dias);
+    return `Venció hace ${abs} día${abs === 1 ? "" : "s"}`;
+  }
+  if (dias === 0) return "¡Vence hoy!";
+  if (dias === 1) return "Vence mañana";
+  return `Vence en ${dias} días`;
+}
+
 /** Suma `dias` a hoy y devuelve la fecha resultante (para presets de vencimiento). */
 export function sumarDias(dias: number, base: Date = new Date()): Date {
   const fecha = new Date(base);

--- a/src/store/notificaciones.ts
+++ b/src/store/notificaciones.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface NotificacionesState {
+  /** Preferencia del usuario (además del permiso del navegador): apagarla
+   * silencia las alertas sin tocar los permisos del sitio. */
+  habilitadas: boolean;
+  setHabilitadas: (habilitadas: boolean) => void;
+}
+
+export const useNotificacionesStore = create<NotificacionesState>()(
+  persist(
+    (set) => ({
+      habilitadas: false,
+      setHabilitadas: (habilitadas) => set({ habilitadas }),
+    }),
+    { name: "gondolapp-notificaciones" }
+  )
+);


### PR DESCRIPTION
## 📝 Descripción

Segunda tanda de mejoras del módulo de vencimiento (continúa el PR #92): ahora la app **avisa** cuando un producto pasa a urgente, en vez de depender de que alguien abra la pestaña.

**Badge de urgentes**
- Burbuja roja con el conteo de items urgentes (vencidos + críticos) sobre el ícono del tab "Vencimientos" (`TabBar`).
- Mismo conteo en el ícono de la app instalada vía Badging API (`navigator.setAppBadge`), donde el navegador lo soporte.

**Notificaciones locales**
- Cuando un item **entra** en nivel urgente (crítico o vencido), se dispara una notificación con el nombre del producto y la urgencia ("¡Vence hoy!", "Venció hace 2 días"); varios items se agrupan en un solo aviso ("N productos urgentes por vencimiento").
- Se muestran vía service worker — el `notificationclick` ya existente en `sw.js` abre `/?view=vencimiento` al tocarla — con fallback a `Notification` directa en desktop.
- Registro de "ya notificado" por item+nivel en localStorage: no se repite la misma alerta en cada refetch, pero pasar de crítico a vencido vuelve a avisar. El registro se poda cuando los items se retiran o corrigen fecha.
- Campanita en el header de la vista Vencimientos para activar/desactivar: pide el permiso del navegador la primera vez y guarda la preferencia en un store zustand persistido. Se oculta si el navegador no expone `Notification` (iOS Safari sin instalar la PWA).

**Limpieza aprovechada**
- `mensajeVencimiento()` extraído a `lib/utils` y reutilizado en `VencimientoItem` (elimina lógica duplicada y corrige el plural "Venció hace 1 días").

**Alcance**: son notificaciones **locales** (la app abierta o en background con SW). El push real con la app cerrada (web-push + cron de Supabase + tabla de suscripciones) queda para un PR aparte — la lógica de selección/mensaje de este PR se reutiliza tal cual.

## 🎯 Tipo de cambio

- [ ] 🐛 Bug fix (cambio que corrige un problema)
- [x] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [ ] 💥 Breaking change (cambio que rompe compatibilidad)
- [ ] 📚 Documentación
- [x] 🎨 Mejora de UI/UX
- [ ] ⚡ Mejora de rendimiento
- [ ] ♻️ Refactorización

## 🔗 Issue relacionado

N/A (continúa #92)

## 🧪 Testing

- [x] 166 tests pasan (`vitest run`), 9 nuevos: selección de items a notificar, poda del registro, armado del mensaje y plurales de `mensajeVencimiento`
- [x] `next build` en verde, lint sin errores nuevos, `tsc --noEmit` limpio
- [ ] Probado en móvil (requiere PWA instalada para badge de ícono y notificaciones en Android)
- [x] Funciona offline (PWA) — el conteo sale del cache persistido de React Query

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado el código en áreas difíciles de entender
- [x] Mis cambios no generan warnings nuevos
- [x] He actualizado la documentación correspondiente (comentarios en código)
- [x] Los tests existentes pasan correctamente

## 📸 Screenshots (si aplica)

Cambios visuales: burbuja roja de conteo en el tab Vencimientos y campanita en el header de esa vista.

## 🎯 Instrucciones de testing

1. Registrar un producto con vencimiento `+7d` (queda crítico): el tab "Vencimientos" debe mostrar la burbuja con el conteo.
2. En la vista Vencimientos, tocar la campanita del header y aceptar el permiso: debe aparecer el toast de confirmación.
3. Registrar otro producto urgente (o recargar): debe llegar una notificación con el nombre del producto; tocarla abre la vista de vencimientos.
4. Recargar la app: la notificación **no** debe repetirse para los mismos items.
5. Con la PWA instalada (Android/desktop Chrome), verificar el número en el ícono de la app; retirar todos los urgentes debe limpiarlo.

## 📌 Notas adicionales

- En iOS las notificaciones web requieren la PWA instalada (iOS 16.4+); sin instalar, la campanita directamente no se muestra.
- Siguientes pasos del backlog: push real con la app cerrada (web-push + cron), retiro parcial de unidades, detección de duplicados al escanear, endurecer RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7C5X7S3Vesi6RW1pWL3eE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7C5X7S3Vesi6RW1pWL3eE)_