### PR TITLE
Fase 0 multi-tienda: inyección de client, query keys centralizadas y harness de integración

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -278,3 +278,36 @@ if (!dataOFF) {
 ☐ Intentar de nuevo → Reabre scanner
 ☐ Modal de loading → Aparece durante búsqueda
 ```
+
+---
+
+## 🔌 Tests de integración contra Supabase real (julio 2026)
+
+Además de la suite de unidad (`npm test`, Supabase mockeado), existe un harness de
+integración que corre contra un stack de Supabase **real** — es la base de la suite
+de aislamiento RLS de la Fase 2 del proyecto multi-tienda (`docs/SPECMULTIUSER.md` §2.4).
+
+```bash
+# 1. Levantar el stack local (requiere Docker; usa supabase/config.toml
+#    y aplica supabase/migrations/)
+supabase start
+
+# 2. Exportar las keys que imprime el stack local
+supabase status   # → anon key y service_role key
+export SUPABASE_ANON_KEY=<anon key>
+export SUPABASE_SERVICE_ROLE_KEY=<service_role key>
+# SUPABASE_URL es opcional (default http://127.0.0.1:54321)
+
+# 3. Correr la suite
+npm run test:integration
+```
+
+- Config: `vitest.integration.config.ts` (environment `node`, **sin mocks**),
+  excluida del `npm test` default y del coverage.
+- Helpers: `src/tests/integration/helpers.ts` — clientes anon/admin y fixtures de
+  usuarios reales creados vía Admin API (`crearUsuarioDePrueba` devuelve un cliente
+  ya autenticado con JWT de verdad).
+- Las keys **no** se hardcodean (ni las demo del stack local): se leen de env vars
+  y la suite falla rápido con instrucciones si faltan.
+- `src/tests/integration/smoke.test.ts` verifica el harness en sí; debe seguir
+  verde en todas las fases del roadmap multi-tienda.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",

--- a/src/components/CatalogoSyncProvider.tsx
+++ b/src/components/CatalogoSyncProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
+import { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
 import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";

--- a/src/components/scanner/ScanFlow.tsx
+++ b/src/components/scanner/ScanFlow.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
 import { useHaptics } from "@/hooks/useHaptics";
 import { ProductoEscaneado, useScanProduct } from "@/hooks/useScanProduct";
 import {
@@ -9,6 +8,7 @@ import {
   useEliminarReposicionItemDirecto,
 } from "@/hooks/useReposicion";
 import { useAgregarVencimientoItem } from "@/hooks/useVencimiento";
+import { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
 import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useRecentsStore } from "@/store/recents";
 import { ScanMode } from "@/types";

--- a/src/hooks/useCatalogoCompleto.ts
+++ b/src/hooks/useCatalogoCompleto.ts
@@ -1,9 +1,10 @@
 "use client";
 
+import { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
 import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useQuery } from "@tanstack/react-query";
 
-export const CATALOGO_COMPLETO_KEY = ["catalogo", "completo"] as const;
+export { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
 
 /**
  * Todo el catálogo (bases + variantes + definiciones de atributos) en una

--- a/src/hooks/useReposicion.tsx
+++ b/src/hooks/useReposicion.tsx
@@ -3,15 +3,16 @@
 import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
 import { ejecutarMasivoOEncolar, ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
 import { crearTempId } from "@/lib/outbox/types";
+import {
+  REPOSICION_ESTADISTICAS_KEY as ESTADISTICAS_KEY,
+  REPOSICION_HISTORIAL_KEY as HISTORIAL_KEY,
+  REPOSICION_ITEMS_KEY as ITEMS_KEY,
+} from "@/lib/queryKeys";
 import * as reposicionService from "@/services/reposicion";
 import { EstadoReposicion, ItemReposicion } from "@/types";
 import { QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import toast from "react-hot-toast";
-
-const ITEMS_KEY = ["reposicion", "items"] as const;
-const HISTORIAL_KEY = ["reposicion", "historial"] as const;
-const ESTADISTICAS_KEY = ["reposicion", "estadisticas"] as const;
 
 export function useReposicionItems() {
   return useQuery({ queryKey: ITEMS_KEY, queryFn: reposicionService.listarItems });

--- a/src/hooks/useScanProduct.ts
+++ b/src/hooks/useScanProduct.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
 import { buscarPorCodigoBarrasLocal } from "@/lib/catalogoLocal";
+import { CATALOGO_COMPLETO_KEY, eanQueryKey } from "@/lib/queryKeys";
 import { buscarPorCodigoBarras, CatalogoCompleto, ProductoCompleto } from "@/services/catalogo";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -41,9 +41,7 @@ export type ScanLookupResult =
  * sesión actual (encadenando varios ítems) no pague otro round-trip. */
 const EAN_STALE_TIME = 10 * 60_000;
 
-export function eanQueryKey(ean: string) {
-  return ["producto", "ean", ean] as const;
-}
+export { eanQueryKey } from "@/lib/queryKeys";
 
 export function useScanProduct() {
   const queryClient = useQueryClient();

--- a/src/hooks/useVencimiento.tsx
+++ b/src/hooks/useVencimiento.tsx
@@ -3,14 +3,15 @@
 import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
 import { ejecutarMasivoOEncolar, ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
 import { crearTempId } from "@/lib/outbox/types";
+import {
+  VENCIMIENTO_ESTADISTICAS_KEY as ESTADISTICAS_KEY,
+  VENCIMIENTO_HISTORIAL_KEY as HISTORIAL_KEY,
+  VENCIMIENTO_ITEMS_KEY as ITEMS_KEY,
+} from "@/lib/queryKeys";
 import { calcularNivelAlerta, toDateInputValue } from "@/lib/utils";
 import * as vencimientoService from "@/services/vencimiento";
 import { ItemVencimientoConAlerta } from "@/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
-const ITEMS_KEY = ["vencimiento", "items"] as const;
-const HISTORIAL_KEY = ["vencimiento", "historial"] as const;
-const ESTADISTICAS_KEY = ["vencimiento", "estadisticas"] as const;
 
 export function useVencimientoItems() {
   return useQuery({

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,22 @@
+/**
+ * Definiciones centralizadas de las query keys de React Query.
+ *
+ * Única fuente de verdad para las keys que comparten hooks, providers y el
+ * persister (ver docs/SPECMULTIUSER.md §4.1): en la Fase 2 del proyecto
+ * multi-tienda todas ganan el prefijo `["tienda", tiendaId, ...]` tocando
+ * solo este módulo (las constantes pasan a factories que reciben tiendaId).
+ */
+
+export const REPOSICION_ITEMS_KEY = ["reposicion", "items"] as const;
+export const REPOSICION_HISTORIAL_KEY = ["reposicion", "historial"] as const;
+export const REPOSICION_ESTADISTICAS_KEY = ["reposicion", "estadisticas"] as const;
+
+export const VENCIMIENTO_ITEMS_KEY = ["vencimiento", "items"] as const;
+export const VENCIMIENTO_HISTORIAL_KEY = ["vencimiento", "historial"] as const;
+export const VENCIMIENTO_ESTADISTICAS_KEY = ["vencimiento", "estadisticas"] as const;
+
+export const CATALOGO_COMPLETO_KEY = ["catalogo", "completo"] as const;
+
+export function eanQueryKey(ean: string) {
+  return ["producto", "ean", ean] as const;
+}

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   AtributosVariante,
   CategoriaAtributo,
@@ -188,7 +189,8 @@ function sanitizarAtributos(atributos?: AtributosVariante): AtributosVariante {
  * el mismo nombre + marca.
  */
 export async function crearProductoManual(
-  dto: CrearProductoDTO
+  dto: CrearProductoDTO,
+  client: SupabaseClient = supabase
 ): Promise<ProductoCompleto> {
   // Los dos checks de existencia son independientes entre sí: se disparan
   // en paralelo para no pagar dos round-trips secuenciales antes de poder
@@ -197,7 +199,7 @@ export async function crearProductoManual(
     { data: existente, error: buscarError },
     { data: baseExistente, error: baseBuscarError },
   ] = await Promise.all([
-    supabase
+    client
       .from("producto_variantes")
       .select("id")
       .eq("codigo_barras", dto.ean)
@@ -205,7 +207,7 @@ export async function crearProductoManual(
     // ilike sin comodines = igualdad case-insensitive: reutiliza la base
     // aunque el tipeo difiera en mayúsculas ("MILEX" → base "Milex"), en
     // vez de chocar con el índice único de la migración 0010.
-    supabase
+    client
       .from("producto_bases")
       .select("*")
       .ilike("nombre", dto.productoBase.nombre.trim())
@@ -220,7 +222,7 @@ export async function crearProductoManual(
 
   let baseRow = baseExistente as ProductoBaseRow | null;
   if (!baseRow) {
-    const { data, error } = await supabase
+    const { data, error } = await client
       .from("producto_bases")
       .insert({
         nombre: dto.productoBase.nombre.trim(),
@@ -238,7 +240,7 @@ export async function crearProductoManual(
   // trigger de BD (migración 0008), que lo arma desde atributos con el
   // orden de la categoría. Así imports masivos o fixes por SQL nunca lo
   // dejan desincronizado de la búsqueda ilike.
-  const { data: varianteRow, error: varianteError } = await supabase
+  const { data: varianteRow, error: varianteError } = await client
     .from("producto_variantes")
     .insert({
       producto_base_id: baseRow.id,
@@ -304,8 +306,10 @@ export interface DefinicionesAtributos {
  * formulario dinámico, con qué etiqueta/orden y qué valores sugerir.
  * La tabla es diminuta (unas filas por categoría), se trae entera.
  */
-export async function obtenerDefinicionesAtributos(): Promise<DefinicionesAtributos> {
-  const { data, error } = await supabase
+export async function obtenerDefinicionesAtributos(
+  client: SupabaseClient = supabase
+): Promise<DefinicionesAtributos> {
+  const { data, error } = await client
     .from("categoria_atributos")
     .select("categoria, clave, etiqueta, orden, sugerencias")
     .order("orden");
@@ -329,11 +333,13 @@ export async function obtenerDefinicionesAtributos(): Promise<DefinicionesAtribu
 }
 
 /** Marcas y categorías existentes, para autocompletar el formulario de alta manual. */
-export async function obtenerMarcasYCategorias(): Promise<{
+export async function obtenerMarcasYCategorias(
+  client: SupabaseClient = supabase
+): Promise<{
   marcas: string[];
   categorias: string[];
 }> {
-  const { data, error } = await supabase
+  const { data, error } = await client
     .from("producto_bases")
     .select("marca, categoria");
   if (error) throw error;

--- a/src/services/parseoProducto.ts
+++ b/src/services/parseoProducto.ts
@@ -6,6 +6,7 @@ import {
 } from "@/services/catalogo";
 import { AtributosVariante, ProductoParseado } from "@/types";
 import Anthropic from "@anthropic-ai/sdk";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 // Server-only: usa ANTHROPIC_API_KEY / GEMINI_API_KEY (sin NEXT_PUBLIC_).
 // Importar este módulo solo desde API routes; en el cliente no hay key y el
@@ -291,7 +292,10 @@ async function parsearConGemini(
  * Anthropic (Haiku 4.5) mientras haya key y crédito; Gemini como fallback
  * automático (o único proveedor si solo hay GEMINI_API_KEY).
  */
-export async function parsearProducto(texto: string): Promise<ProductoParseado> {
+export async function parsearProducto(
+  texto: string,
+  client: SupabaseClient = supabase
+): Promise<ProductoParseado> {
   const anthropicConfigurado = Boolean(process.env.ANTHROPIC_API_KEY);
   const geminiConfigurado = Boolean(process.env.GEMINI_API_KEY);
   if (!anthropicConfigurado && !geminiConfigurado) {
@@ -299,12 +303,12 @@ export async function parsearProducto(texto: string): Promise<ProductoParseado> 
   }
 
   const [{ marcas, categorias }, defs, basesResult] = await Promise.all([
-    obtenerMarcasYCategorias(),
-    obtenerDefinicionesAtributos(),
+    obtenerMarcasYCategorias(client),
+    obtenerDefinicionesAtributos(client),
     // El orden estable importa: el system prompt se cachea por prefijo exacto
     // de bytes, y sin .order() Postgres no garantiza orden — cada request
     // generaría un prompt distinto y el caché nunca pegaría.
-    supabase
+    client
       .from("producto_bases")
       .select("nombre, marca, categoria")
       .order("nombre")

--- a/src/tests/integration/helpers.ts
+++ b/src/tests/integration/helpers.ts
@@ -1,0 +1,90 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Helpers del harness de integración (docs/SPECMULTIUSER.md §2.4): clientes
+ * contra un stack de Supabase real y fixtures de usuarios con JWTs de
+ * verdad, creados vía Admin API con la service_role key.
+ *
+ * Las keys NO se hardcodean (ni siquiera las demo del stack local, para no
+ * disparar escáneres de secretos): se leen de env vars. Con el stack local
+ * corriendo, `supabase status` las imprime.
+ */
+
+export const SUPABASE_URL =
+  process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+/** Falla rápido con instrucciones si el entorno no está configurado. */
+export function verificarConfiguracion(): void {
+  if (SUPABASE_ANON_KEY && SUPABASE_SERVICE_ROLE_KEY) return;
+  throw new Error(
+    [
+      "Tests de integración sin configurar. Necesitan un stack de Supabase real:",
+      "  1. supabase start   (requiere Docker; usa supabase/config.toml)",
+      "  2. supabase status  (imprime las keys del stack local)",
+      "  3. export SUPABASE_ANON_KEY=<anon key>",
+      "     export SUPABASE_SERVICE_ROLE_KEY=<service_role key>",
+      "     (SUPABASE_URL opcional; default http://127.0.0.1:54321)",
+      "  4. npm run test:integration",
+    ].join("\n")
+  );
+}
+
+export function crearClienteAnon(): SupabaseClient {
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+/** Cliente con service_role: solo para fixtures (crear/borrar usuarios). */
+export function crearClienteAdmin(): SupabaseClient {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export interface UsuarioDePrueba {
+  id: string;
+  email: string;
+  /** Cliente ya autenticado con el JWT real de este usuario. */
+  client: SupabaseClient;
+}
+
+export async function crearUsuarioDePrueba(
+  admin: SupabaseClient,
+  prefijo = "test"
+): Promise<UsuarioDePrueba> {
+  const email = `${prefijo}-${randomUUID()}@integration.local`;
+
+  const { data: creado, error: crearError } =
+    await admin.auth.admin.createUser({ email, email_confirm: true });
+  if (crearError) throw crearError;
+
+  // Sin contraseñas: el login consume un magic link generado por la Admin
+  // API (no se envía ningún email; el token se canjea directo por sesión).
+  const { data: link, error: linkError } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+  });
+  if (linkError) throw linkError;
+
+  const client = crearClienteAnon();
+  const { error: loginError } = await client.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: link.properties.hashed_token,
+  });
+  if (loginError) throw loginError;
+
+  return { id: creado.user.id, email, client };
+}
+
+export async function eliminarUsuarioDePrueba(
+  admin: SupabaseClient,
+  usuario: UsuarioDePrueba
+): Promise<void> {
+  await usuario.client.auth.signOut();
+  const { error } = await admin.auth.admin.deleteUser(usuario.id);
+  if (error) throw error;
+}

--- a/src/tests/integration/smoke.test.ts
+++ b/src/tests/integration/smoke.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  crearClienteAdmin,
+  crearUsuarioDePrueba,
+  eliminarUsuarioDePrueba,
+  verificarConfiguracion,
+} from "./helpers";
+
+/**
+ * Smoke test del harness: verifica que el stack responde, que la Admin API
+ * puede crear/borrar usuarios y que un usuario autenticado con JWT real
+ * puede consultar sin error. No asegura nada sobre RLS — eso es la suite de
+ * aislamiento de la Fase 2 (docs/SPECMULTIUSER.md §2.4); este test debe
+ * seguir verde en todas las fases.
+ */
+
+beforeAll(() => {
+  verificarConfiguracion();
+});
+
+describe("harness de integración (smoke)", () => {
+  it("crea un usuario real, consulta autenticado y lo elimina", async () => {
+    const admin = crearClienteAdmin();
+    const usuario = await crearUsuarioDePrueba(admin);
+    expect(usuario.id).toBeTruthy();
+
+    // El contenido visible depende de la fase de RLS; que la query no
+    // falle es lo único invariante entre fases.
+    const { error } = await usuario.client
+      .from("producto_bases")
+      .select("id", { head: true, count: "exact" });
+    expect(error).toBeNull();
+
+    await eliminarUsuarioDePrueba(admin, usuario);
+  });
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,4 @@
+# Config mínima del stack local (`supabase start` + `supabase db reset`
+# aplica supabase/migrations/). El CLI completa el resto con defaults;
+# `supabase init` regeneraría la versión completa si hiciera falta.
+project_id = "gondolapp-beta"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
@@ -8,6 +8,9 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/tests/setup.ts'],
+    // Los tests de integración hablan con un stack de Supabase real y corren
+    // aparte (npm run test:integration, ver vitest.integration.config.ts).
+    exclude: [...configDefaults.exclude, 'src/tests/integration/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+/**
+ * Config de los tests de integración: corren contra un stack de Supabase
+ * REAL (local vía `supabase start`, o el branch de staging), sin jsdom y
+ * sin ningún mock. Ver src/tests/integration/README.md para levantarlo.
+ *
+ * Separado del run default a propósito: `npm test` debe seguir siendo verde
+ * sin Docker ni stack local. Esta suite es el gate de la Fase 2 del
+ * proyecto multi-tienda (docs/SPECMULTIUSER.md §2.4).
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/tests/integration/**/*.test.ts'],
+    // Sin setupFiles: acá no se mockea nada.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## 📝 Descripción

Fase 0 del roadmap de `docs/SPECMULTIUSER.md` — preparación **sin cambio de comportamiento**:

1. **Inyección de cliente en los servicios server-usables**: `crearProductoManual`, `obtenerDefinicionesAtributos` y `obtenerMarcasYCategorias` (`src/services/catalogo.ts`) y `parsearProducto` (`src/services/parseoProducto.ts`, incluida su query directa a `producto_bases`) aceptan un `client: SupabaseClient` con default al singleton del browser. En la Fase 2 los route handlers pasarán un cliente por-request creado desde cookies; hoy nadie pasa el parámetro y el comportamiento es idéntico.
2. **Query keys centralizadas** en `src/lib/queryKeys.ts` (nuevo): las definiciones que vivían repartidas en `useReposicion.tsx`, `useVencimiento.tsx`, `useCatalogoCompleto.ts` y `useScanProduct.ts` ahora tienen una única fuente de verdad — en la Fase 2 el prefijo `["tienda", tiendaId, ...]` se agrega tocando solo ese módulo. Los hooks re-exportan sus keys para no romper imports existentes (los tests quedaron intactos a propósito, como prueba de neutralidad).
3. **Harness de tests de integración** (base de la suite de aislamiento RLS de la Fase 2, spec §2.4): `vitest.integration.config.ts` (node, sin mocks, excluido del `npm test` default), `src/tests/integration/helpers.ts` (fixtures de usuarios reales vía Admin API con JWTs de verdad), smoke test, script `npm run test:integration`, `supabase/config.toml` mínimo para `supabase start`, y sección nueva en `docs/TESTING.md`. Las keys se leen de env vars — no se hardcodea ninguna, ni las demo del stack local.

## 🎯 Tipo de cambio

- [x] ♻️ Refactorización

## 🔗 Issue relacionado

Roadmap de `docs/SPECMULTIUSER.md` (Fase 0).

## 🧪 Testing

- [x] Los 166 tests de unidad pasan sin modificar ningún test existente
- [x] `tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos (las 10 warnings son preexistentes en archivos no tocados)
- [x] `next build` OK

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] Mis cambios no generan warnings nuevos
- [x] He actualizado la documentación correspondiente
- [x] Los tests existentes pasan correctamente

## 📸 Screenshots (si aplica)

N/A — refactor sin cambio visual.

## 🎯 Instrucciones de testing

1. `npm test` → 166 verdes (la suite de integración no corre acá).
2. Con Docker: `supabase start`, exportar las keys de `supabase status` (`SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) y correr `npm run test:integration` → smoke verde.
3. Verificar en la app que escanear/buscar/listas funcionan igual que antes (mismas query keys, mismo singleton por default).

## 📌 Notas adicionales

Quedan como pasos operativos de la Fase 0 (fuera de este PR): el branch/staging de Supabase con dump de producción para ensayar la migración `0012`, y correr el smoke del harness en una máquina con Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW)_