### PR TITLE
Fase 1 multi-tienda: auth end-to-end, migración 0012 y corte de anon

### DIFF
--- a/docs/DEPLOY-FASE1.md
+++ b/docs/DEPLOY-FASE1.md
@@ -1,0 +1,129 @@
+# 🚀 Runbook: deploy coordinado de la Fase 1 (auth + corte de anon)
+
+> Acompaña al PR de Fase 1 y a `supabase/migrations/0012_tiendas_y_backfill.sql`.
+> **Por qué es coordinado**: al aplicar la 0012, toda PWA sin login recibe 401/403
+> en todo (riesgo 🔴 de `SPECMULTIUSER.md`). El orden de este runbook hace que el
+> teléfono de la tienda nunca vea ese corte.
+
+## Resumen del orden (el porqué está en cada sección)
+
+1. **Días antes** — Ensayo en staging (A) + configuración de Auth en el dashboard (B). Ninguno toca producción.
+2. **Día D** — (C): backup → crear tu usuario → merge/deploy → actualizar la PWA del teléfono y loguearte **con la base todavía abierta** → aplicar la migración → alta de membresía → verificar.
+
+Con ese orden, el teléfono ya está logueado cuando cae el corte de `anon`: cero downtime para la tienda.
+
+---
+
+## A. Ensayo en staging (días antes)
+
+Objetivo: correr la 0012 contra una copia con **schema y datos reales** y ver que backfill, constraints y counts salen bien.
+
+Prerequisitos: Docker, `supabase` CLI, y la connection string de producción (dashboard → Settings → Database).
+
+```bash
+# 1. Vincular el repo al proyecto (una sola vez)
+supabase login
+supabase link --project-ref <REF-DEL-PROYECTO>
+
+# 2. Sacar la 0012 temporalmente para que el stack local quede en el estado
+#    actual de producción (0001–0011)
+mv supabase/migrations/0012_tiendas_y_backfill.sql /tmp/
+
+# 3. Stack local con el schema de las migraciones 0001–0011
+supabase start
+supabase db reset
+
+# 4. Traer los DATOS de producción y cargarlos en local
+supabase db dump --linked --data-only -f /tmp/data-prod.sql
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -f /tmp/data-prod.sql
+
+# 5. Restaurar la 0012 y aplicarla en una transacción (como hará el deploy real)
+mv /tmp/0012_tiendas_y_backfill.sql supabase/migrations/
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+  --single-transaction -f supabase/migrations/0012_tiendas_y_backfill.sql
+```
+
+**Verificar en el ensayo** (psql o Studio local, http://127.0.0.1:54323):
+
+```sql
+-- counts intactos vs producción (anotalos antes)
+select count(*) from producto_variantes;
+-- tienda_id completo en las 8 tablas
+select count(*) from items_reposicion where tienda_id is null;  -- 0
+-- la tienda inicial existe
+select * from tiendas;
+```
+
+Y con la app: `.env.local` apuntando al stack local (`supabase status` imprime URL y anon key), crear un usuario en el Studio local (Authentication → Add user), `npm run dev`, login y operar las listas. `npm run test:integration` también corre contra este stack.
+
+**Si no hay Docker disponible**: mismo ensayo contra un segundo proyecto gratuito de Supabase ("espejo"): restaurar ahí el dump completo (`supabase db dump --linked -f full.sql` + psql contra el espejo) y aplicar la 0012 encima.
+
+## B. Configuración de Auth en el dashboard (días antes — no rompe nada)
+
+En el proyecto de **producción**, dashboard → Authentication:
+
+1. **Sign In / Up** → desactivar **"Allow new users to sign up"** (las cuentas de Fases 1–2 se crean a mano; se reactiva en Fase 3). Verificar que "Confirm email" quede **desactivado**.
+2. **Sessions** → time-box y "inactivity timeout" **deshabilitados** (default). Una semana sin abrir la app no debe matar la sesión.
+3. **URL Configuration** → Site URL: `https://gondolapp.digital`, y en **Redirect URLs** agregar `https://gondolapp.digital/restablecer` — sin esto, el enlace de recuperación de contraseña no vuelve a la app.
+4. **SMTP custom (Resend)** — el built-in solo sirve para testing:
+   - En Resend: agregar el dominio `gondolapp.digital`, cargar los registros DNS que pide (SPF/DKIM) y crear una API key.
+   - En Supabase → Authentication → Emails → SMTP Settings: host `smtp.resend.com`, puerto `465`, usuario `resend`, contraseña = la API key, sender `noreply@gondolapp.digital`.
+   - Probar con un "Reset password" desde el dashboard a tu propio email.
+
+## C. Día D (ventana de ~30 min, con la tienda tranquila)
+
+> El free tier **no** tiene backups automáticos: el paso 1 no es opcional.
+
+1. **Backup manual**: `supabase db dump --linked -f backup-pre-fase1.sql` (schema + datos). Guardarlo fuera del repo.
+2. **Crear tu usuario real**: dashboard → Authentication → Users → Add user (email + contraseña, auto-confirm). Inofensivo: solo existe, no cambia nada.
+3. **Merge del PR de Fase 1** → esperar el deploy de Vercel en verde. En este momento: los visitantes nuevos ven `/login`; la base sigue abierta como hoy, así que nada se rompe todavía.
+4. **En el teléfono de la tienda**: abrir la PWA → aceptar el prompt "Nueva versión disponible → Actualizar ahora" (o cerrar y reabrir la app) → login con el usuario del paso 2 → verificar que las listas se ven. **No seguir hasta que este paso esté OK** — es lo que hace que el corte de anon no lo afecte.
+5. **Aplicar la migración 0012 a producción** (transaccional; si falla, no queda nada a medias). Dos caminos:
+   - SQL Editor del dashboard: pegar el contenido completo de `0012_tiendas_y_backfill.sql` y ejecutar; **o**
+   - CLI: `supabase db push` — solo si `supabase migration list` muestra las 0001–0011 como aplicadas (si el historial de migraciones no está inicializado, usar el SQL Editor).
+6. **Alta de membresía admin** (SQL Editor) — no la necesita la Fase 1 para operar (el RLS intermedio no mira membresías), pero deja todo listo para las Fases 2–3:
+
+   ```sql
+   insert into tienda_miembros (tienda_id, user_id, rol)
+   select 'a9defb27-54dd-4cb8-853f-2c901f8365dd', id, 'admin'
+   from auth.users
+   where email = '<TU-EMAIL>';
+   ```
+
+7. **Verificación post-deploy**:
+
+   ```bash
+   # anon cortado en PostgREST (debe devolver [] o error, nunca datos)
+   curl "https://<REF>.supabase.co/rest/v1/items_reposicion?select=id" \
+     -H "apikey: <ANON-KEY>"
+   # RPC cortada para anon (debe dar permission denied / 401)
+   curl -X POST "https://<REF>.supabase.co/rest/v1/rpc/guardar_lista_reposicion" \
+     -H "apikey: <ANON-KEY>" -H "Content-Type: application/json" -d '{}'
+   ```
+
+   En la app (logueado): escanear un producto, agregar a la lista, **crear un producto manual** (ejercita el gate 401 + cliente por-request), pedir un reset de contraseña (ejercita Resend), y modo avión → reabrir la PWA → las listas deben verse (arranque offline con sesión). En DevTools → Application → Cache Storage: no debe haber entradas de `*.supabase.co`.
+
+## Rollback de emergencia
+
+- **La app rota post-deploy, base sin migrar todavía** → "Instant Rollback" en Vercel y listo.
+- **La app rota DESPUÉS de la migración** → revertir el deploy en Vercel **no alcanza**: el código viejo opera como `anon` y la base ya lo rechaza. Reabrir `anon` mientras se investiga:
+
+  ```sql
+  -- SOLO EMERGENCIA: restaura el acceso anon pre-0012 (dejar registrado y
+  -- revertir en cuanto se resuelva)
+  create policy "allow_all_anon" on producto_bases for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on producto_variantes for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on categoria_atributos for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on items_reposicion for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on listas_reposicion_historial for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on items_reposicion_historial for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on items_vencimiento for all to anon using (true) with check (true);
+  create policy "allow_all_anon" on items_vencimiento_historial for all to anon using (true) with check (true);
+  grant execute on function agregar_item_reposicion(uuid, integer) to anon;
+  grant execute on function guardar_lista_reposicion() to anon;
+  grant execute on function retirar_item_vencimiento(uuid) to anon;
+  grant execute on function retirar_items_vencimiento(uuid[]) to anon;
+  grant execute on function obtener_estadisticas_vencimiento(timestamptz, timestamptz) to anon;
+  ```
+
+  (Las columnas `tienda_id` y las tablas nuevas pueden quedar: el código viejo no las mira y los DEFAULT completan los inserts.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
+        "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.45.4",
         "@tanstack/query-async-storage-persister": "^5.101.2",
         "@tanstack/react-query": "^5.17.0",
@@ -3782,6 +3783,18 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.0.tgz",
+      "integrity": "sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.108.0"
+      }
+    },
     "node_modules/@supabase/storage-js": {
       "version": "2.110.0",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.0.tgz",
@@ -6236,6 +6249,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.46.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
+    "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.45.4",
     "@tanstack/query-async-storage-persister": "^5.101.2",
     "@tanstack/react-query": "^5.17.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,6 @@
-const CACHE_VERSION = "v2";
+// v3: exclusión de *.supabase.co del cache (privacidad multi-usuario) y
+// llegada del login — el bump fuerza el ciclo de update en clientes viejos.
+const CACHE_VERSION = "v3";
 const CACHE_NAME = `gondolapp-${CACHE_VERSION}`;
 const STATIC_CACHE = `gondolapp-static-${CACHE_VERSION}`;
 const DYNAMIC_CACHE = `gondolapp-dynamic-${CACHE_VERSION}`;
@@ -89,6 +91,14 @@ self.addEventListener("fetch", (event) => {
 
   // Ignorar hot-reload en desarrollo
   if (url.pathname.includes("_next/webpack-hmr")) {
+    return;
+  }
+
+  // Nunca cachear Supabase (REST/Auth/Storage): el offline de datos lo
+  // maneja el persister de React Query en IDB, aislado por identidad.
+  // Cachear estas respuestas en Cache Storage filtraría datos entre
+  // usuarios del mismo dispositivo (docs/SPECMULTIUSER.md §6).
+  if (url.hostname.endsWith(".supabase.co")) {
     return;
   }
 

--- a/src/app/api/productos/crear-manual/route.ts
+++ b/src/app/api/productos/crear-manual/route.ts
@@ -1,3 +1,4 @@
+import { crearClienteServidor } from "@/lib/supabaseServer";
 import {
   crearProductoManual,
   obtenerDefinicionesAtributos,
@@ -46,6 +47,19 @@ function canonicalizarAtributos(
  */
 export async function POST(request: NextRequest) {
   try {
+    // Cliente por-request con el JWT del usuario: desde la migración 0012
+    // `anon` no tiene acceso y el singleton browser operaría como anon.
+    const supabase = await crearClienteServidor();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "No autenticado" },
+        { status: 401 }
+      );
+    }
+
     const body: CrearProductoDTO = await request.json();
 
     if (!body.ean || !body.productoBase?.nombre || !body.productoBase?.marca) {
@@ -67,7 +81,7 @@ export async function POST(request: NextRequest) {
     // perder el alta por un fallo del lookup sería peor que un valor sin canon.
     let atributos = atributosCrudos;
     try {
-      const defs = await obtenerDefinicionesAtributos();
+      const defs = await obtenerDefinicionesAtributos(supabase);
       const categoria = body.productoBase.categoria?.trim();
       const defsAplicables =
         (categoria && defs.porCategoria[categoria]) || defs.default;
@@ -76,10 +90,13 @@ export async function POST(request: NextRequest) {
       // sin canonicalización
     }
 
-    const producto = await crearProductoManual({
-      ...body,
-      variante: { ...body.variante, atributos },
-    });
+    const producto = await crearProductoManual(
+      {
+        ...body,
+        variante: { ...body.variante, atributos },
+      },
+      supabase
+    );
 
     return NextResponse.json({
       success: true,
@@ -120,9 +137,20 @@ export async function POST(request: NextRequest) {
  */
 export async function GET() {
   try {
+    const supabase = await crearClienteServidor();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "No autenticado" },
+        { status: 401 }
+      );
+    }
+
     const [{ marcas, categorias }, defs] = await Promise.all([
-      obtenerMarcasYCategorias(),
-      obtenerDefinicionesAtributos(),
+      obtenerMarcasYCategorias(supabase),
+      obtenerDefinicionesAtributos(supabase),
     ]);
     return NextResponse.json({
       success: true,

--- a/src/app/api/productos/parsear/route.ts
+++ b/src/app/api/productos/parsear/route.ts
@@ -1,3 +1,4 @@
+import { crearClienteServidor } from "@/lib/supabaseServer";
 import { construirNombreCompleto, ORDEN_ATRIBUTOS_DEFAULT } from "@/lib/utils";
 import { obtenerDefinicionesAtributos } from "@/services/catalogo";
 import {
@@ -18,6 +19,20 @@ const MAX_TEXTO = 200;
  * señal para que el cliente caiga al formulario manual.
  */
 export async function POST(request: NextRequest) {
+  // Gate 401: protege el gasto de IA detrás de auth (no solo del rate
+  // limit por IP) y da un cliente con el JWT del usuario para que RLS
+  // scopee las lecturas del catálogo.
+  const supabase = await crearClienteServidor();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json(
+      { success: false, error: "No autenticado" },
+      { status: 401 }
+    );
+  }
+
   let texto: unknown;
   try {
     ({ texto } = await request.json());
@@ -42,13 +57,13 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const parsed = await parsearProducto(texto.trim());
+    const parsed = await parsearProducto(texto.trim(), supabase);
 
     // Preview del nombre con el mismo orden de claves que usará el trigger
     // de BD al crear (definición de la categoría, o default global).
     let orden: readonly string[] = ORDEN_ATRIBUTOS_DEFAULT;
     try {
-      const defs = await obtenerDefinicionesAtributos();
+      const defs = await obtenerDefinicionesAtributos(supabase);
       const categoria = parsed.productoBase.categoria;
       const defsAplicables =
         (categoria && defs.porCategoria[categoria]) ||

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Toaster } from "react-hot-toast";
 import "./globals.css";
+import { AuthProvider } from "@/components/AuthProvider";
 import CatalogoSyncProvider from "@/components/CatalogoSyncProvider";
 import OutboxProvider from "@/components/OutboxProvider";
 import PWAProvider from "./PWAProvider";
@@ -101,6 +102,9 @@ export default function RootLayout({
         />
       </head>
       <body className="bg-canvas text-fg transition-colors">
+        {/* AuthProvider por fuera de QueryProvider: en la Fase 2 el buster
+            del persister y las query keys dependen de la identidad. */}
+        <AuthProvider>
         <QueryProvider>
           <ThemeProvider>
             <PWAProvider />
@@ -123,6 +127,7 @@ export default function RootLayout({
             {children}
           </ThemeProvider>
         </QueryProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  AuthCard,
+  claseBotonPrimario,
+  claseInput,
+  MensajeError,
+} from "@/components/auth/AuthCard";
+import { supabase } from "@/lib/supabase";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useState } from "react";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setEnviando(true);
+    const { error: loginError } = await supabase.auth.signInWithPassword({
+      email: email.trim(),
+      password,
+    });
+    setEnviando(false);
+    if (loginError) {
+      setError(
+        loginError.message === "Invalid login credentials"
+          ? "Email o contraseña incorrectos"
+          : loginError.message
+      );
+      return;
+    }
+    router.replace("/");
+  }
+
+  return (
+    <AuthCard titulo="Iniciar sesión" subtitulo="Entrá para ver tus listas">
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type="email"
+          autoComplete="email"
+          required
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={claseInput}
+        />
+        <input
+          type="password"
+          autoComplete="current-password"
+          required
+          placeholder="Contraseña"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className={claseInput}
+        />
+        <MensajeError mensaje={error} />
+        <button type="submit" disabled={enviando} className={claseBotonPrimario}>
+          {enviando ? (
+            <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+          ) : (
+            "Entrar"
+          )}
+        </button>
+      </form>
+      <div className="mt-4 flex flex-col gap-2 text-center text-sm">
+        <Link href="/recuperar" className="text-accent">
+          Olvidé mi contraseña
+        </Link>
+        <Link href="/registro" className="text-fg-secondary">
+          ¿No tenés cuenta? <span className="text-accent">Registrate</span>
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BotonCerrarSesion } from "@/components/BotonCerrarSesion";
 import { OutboxBadge } from "@/components/OutboxBadge";
 import { ScanFlow } from "@/components/scanner/ScanFlow";
 import { ProductSearchSheet } from "@/components/search/ProductSearchSheet";
@@ -99,6 +100,7 @@ function HomePageContent() {
                 </Link>
                 <OutboxBadge />
                 <ThemeToggle />
+                <BotonCerrarSesion />
               </>
             }
             bottomSlot={

--- a/src/app/recuperar/page.tsx
+++ b/src/app/recuperar/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  AuthCard,
+  claseBotonPrimario,
+  claseInput,
+  MensajeError,
+} from "@/components/auth/AuthCard";
+import { supabase } from "@/lib/supabase";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { FormEvent, useState } from "react";
+
+export default function RecuperarPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+  const [enviado, setEnviado] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setEnviando(true);
+    const { error: resetError } = await supabase.auth.resetPasswordForEmail(
+      email.trim(),
+      { redirectTo: `${window.location.origin}/restablecer` }
+    );
+    setEnviando(false);
+    if (resetError) {
+      setError(resetError.message);
+      return;
+    }
+    setEnviado(true);
+  }
+
+  if (enviado) {
+    return (
+      <AuthCard titulo="Revisá tu email">
+        <p className="text-sm text-fg-secondary text-center">
+          Si existe una cuenta con ese email, te va a llegar un enlace para
+          restablecer la contraseña.
+        </p>
+        <Link
+          href="/login"
+          className="block text-center text-accent text-sm mt-4"
+        >
+          Volver a iniciar sesión
+        </Link>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      titulo="Recuperar contraseña"
+      subtitulo="Te enviamos un enlace por email"
+    >
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type="email"
+          autoComplete="email"
+          required
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={claseInput}
+        />
+        <MensajeError mensaje={error} />
+        <button type="submit" disabled={enviando} className={claseBotonPrimario}>
+          {enviando ? (
+            <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+          ) : (
+            "Enviar enlace"
+          )}
+        </button>
+      </form>
+      <div className="mt-4 text-center text-sm">
+        <Link href="/login" className="text-accent">
+          Volver a iniciar sesión
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  AuthCard,
+  claseBotonPrimario,
+  claseInput,
+  MensajeError,
+} from "@/components/auth/AuthCard";
+import { supabase } from "@/lib/supabase";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useState } from "react";
+
+export default function RegistroPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+  const [pendienteConfirmacion, setPendienteConfirmacion] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setEnviando(true);
+    const { data, error: signUpError } = await supabase.auth.signUp({
+      email: email.trim(),
+      password,
+    });
+    setEnviando(false);
+    if (signUpError) {
+      // Durante las Fases 1–2 los signups públicos están deshabilitados en
+      // Supabase Auth; se habilitan con el onboarding de la Fase 3.
+      setError(
+        /signup.*(disabled|not allowed)/i.test(signUpError.message)
+          ? "El registro está deshabilitado por ahora. Pedile acceso al encargado."
+          : signUpError.message
+      );
+      return;
+    }
+    if (data.session) {
+      router.replace("/");
+      return;
+    }
+    setPendienteConfirmacion(true);
+  }
+
+  if (pendienteConfirmacion) {
+    return (
+      <AuthCard titulo="Revisá tu email">
+        <p className="text-sm text-fg-secondary text-center">
+          Te enviamos un enlace para confirmar la cuenta. Después vas a poder
+          iniciar sesión.
+        </p>
+        <Link
+          href="/login"
+          className="block text-center text-accent text-sm mt-4"
+        >
+          Volver a iniciar sesión
+        </Link>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard titulo="Crear cuenta" subtitulo="Para el equipo de tu tienda">
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type="email"
+          autoComplete="email"
+          required
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={claseInput}
+        />
+        <input
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={6}
+          placeholder="Contraseña (mínimo 6 caracteres)"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className={claseInput}
+        />
+        <MensajeError mensaje={error} />
+        <button type="submit" disabled={enviando} className={claseBotonPrimario}>
+          {enviando ? (
+            <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+          ) : (
+            "Registrarme"
+          )}
+        </button>
+      </form>
+      <div className="mt-4 text-center text-sm">
+        <Link href="/login" className="text-fg-secondary">
+          ¿Ya tenés cuenta? <span className="text-accent">Iniciá sesión</span>
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}

--- a/src/app/restablecer/page.tsx
+++ b/src/app/restablecer/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  AuthCard,
+  claseBotonPrimario,
+  claseInput,
+  MensajeError,
+} from "@/components/auth/AuthCard";
+import { useAuth } from "@/components/AuthProvider";
+import { supabase } from "@/lib/supabase";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useState } from "react";
+
+/**
+ * Destino del enlace de recuperación: el cliente browser intercambia el
+ * código de la URL por una sesión al cargar (PKCE + detectSessionInUrl),
+ * y acá solo se setea la contraseña nueva sobre esa sesión.
+ */
+export default function RestablecerPage() {
+  const router = useRouter();
+  const { user, cargando } = useAuth();
+  const [password, setPassword] = useState("");
+  const [confirmacion, setConfirmacion] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (password !== confirmacion) {
+      setError("Las contraseñas no coinciden");
+      return;
+    }
+    setError(null);
+    setEnviando(true);
+    const { error: updateError } = await supabase.auth.updateUser({ password });
+    setEnviando(false);
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+    router.replace("/");
+  }
+
+  if (cargando) {
+    return (
+      <AuthCard titulo="Restablecer contraseña">
+        <Loader2 className="w-6 h-6 animate-spin mx-auto text-accent" />
+      </AuthCard>
+    );
+  }
+
+  if (!user) {
+    return (
+      <AuthCard titulo="Enlace inválido">
+        <p className="text-sm text-fg-secondary text-center">
+          El enlace expiró o no es válido. Pedí uno nuevo.
+        </p>
+        <Link
+          href="/recuperar"
+          className="block text-center text-accent text-sm mt-4"
+        >
+          Recuperar contraseña
+        </Link>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard titulo="Nueva contraseña">
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={6}
+          placeholder="Contraseña nueva (mínimo 6 caracteres)"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className={claseInput}
+        />
+        <input
+          type="password"
+          autoComplete="new-password"
+          required
+          placeholder="Repetir contraseña"
+          value={confirmacion}
+          onChange={(e) => setConfirmacion(e.target.value)}
+          className={claseInput}
+        />
+        <MensajeError mensaje={error} />
+        <button type="submit" disabled={enviando} className={claseBotonPrimario}>
+          {enviando ? (
+            <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+          ) : (
+            "Guardar contraseña"
+          )}
+        </button>
+      </form>
+    </AuthCard>
+  );
+}

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { esRutaPublica } from "@/lib/rutasPublicas";
+import { supabase } from "@/lib/supabase";
+import type { User } from "@supabase/supabase-js";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface AuthContextValue {
+  user: User | null;
+  /** true mientras se resuelve la sesión inicial (lectura local, sin red). */
+  cargando: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  cargando: true,
+});
+
+export function useAuth(): AuthContextValue {
+  return useContext(AuthContext);
+}
+
+/**
+ * Sesión de Supabase por contexto + gate client-side.
+ *
+ * El gate del proxy es best-effort (en arranque offline el SW sirve el
+ * shell sin pasar por el Edge): este es el gate real de UX. getSession()
+ * lee la cookie local sin red, así que con sesión local el shell offline
+ * nunca se bloquea — aunque el access token esté vencido, las lecturas
+ * salen del cache IDB y las escrituras van al outbox (spec §3.1).
+ *
+ * Va por fuera de QueryProvider: en la Fase 2 el buster del persister y
+ * las query keys necesitan la identidad antes de montar los providers de
+ * datos.
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [cargando, setCargando] = useState(true);
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    let activo = true;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!activo) return;
+      setUser(data.session?.user ?? null);
+      setCargando(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_evento, session) => {
+      setUser(session?.user ?? null);
+      setCargando(false);
+    });
+
+    return () => {
+      activo = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (cargando || user) return;
+    if (!esRutaPublica(pathname)) router.replace("/login");
+  }, [cargando, user, pathname, router]);
+
+  // Sin sesión en ruta protegida: no renderizar el contenido mientras el
+  // redirect a /login está en vuelo (evita el flash de la app vacía).
+  if (!cargando && !user && !esRutaPublica(pathname)) {
+    return null;
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, cargando }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/components/BotonCerrarSesion.tsx
+++ b/src/components/BotonCerrarSesion.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useCerrarSesion } from "@/hooks/useCerrarSesion";
+import { Loader2, LogOut } from "lucide-react";
+
+/** Botón de logout del header (mismo formato que las demás acciones). */
+export function BotonCerrarSesion() {
+  const { cerrarSesion, cerrando } = useCerrarSesion();
+
+  return (
+    <button
+      onClick={cerrarSesion}
+      disabled={cerrando}
+      aria-label="Cerrar sesión"
+      className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors disabled:opacity-50"
+    >
+      {cerrando ? (
+        <Loader2 size={22} className="animate-spin" />
+      ) : (
+        <LogOut size={22} />
+      )}
+    </button>
+  );
+}

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Marco compartido de las pantallas de auth: canvas centrado a ancho de
+ * teléfono, título de la app y un card con el formulario.
+ */
+export function AuthCard({
+  titulo,
+  subtitulo,
+  children,
+}: {
+  titulo: string;
+  subtitulo?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-dvh bg-canvas flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-accent">GondolApp</h1>
+          <h2 className="mt-4 text-xl font-semibold text-fg">{titulo}</h2>
+          {subtitulo && (
+            <p className="mt-1 text-sm text-fg-secondary">{subtitulo}</p>
+          )}
+        </div>
+        <div className="bg-surface rounded-3xl p-6 shadow-sm">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export const claseInput =
+  "w-full h-12 px-4 rounded-2xl bg-surface-2 text-fg placeholder:text-fg-tertiary outline-none focus:ring-2 focus:ring-accent";
+
+export const claseBotonPrimario =
+  "w-full h-12 rounded-full bg-accent text-on-accent font-semibold disabled:opacity-50 transition-opacity";
+
+export function MensajeError({ mensaje }: { mensaje: string | null }) {
+  if (!mensaje) return null;
+  return (
+    <p role="alert" className="text-sm text-red-500 mt-3">
+      {mensaje}
+    </p>
+  );
+}

--- a/src/hooks/useCerrarSesion.ts
+++ b/src/hooks/useCerrarSesion.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { limpiarEstadoLocal } from "@/lib/limpiarEstadoLocal";
+import { supabase } from "@/lib/supabase";
+import { useOutboxStore } from "@/store/outbox";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+/**
+ * Logout con limpieza local obligatoria (spec §3.2): aviso si hay cambios
+ * sin sincronizar → signOut → limpiarEstadoLocal() → cache en memoria →
+ * /login.
+ */
+export function useCerrarSesion() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [cerrando, setCerrando] = useState(false);
+
+  const cerrarSesion = useCallback(async () => {
+    const pendientes = useOutboxStore.getState().pendingCount;
+    if (pendientes > 0) {
+      const seguir = window.confirm(
+        `Tenés ${pendientes} ${
+          pendientes === 1 ? "cambio" : "cambios"
+        } sin sincronizar que se van a perder. ¿Cerrar sesión igual?`
+      );
+      if (!seguir) return;
+    }
+
+    setCerrando(true);
+    try {
+      try {
+        await supabase.auth.signOut();
+      } catch {
+        // Sin red no se puede revocar el token en el servidor, pero la
+        // sesión local igual se elimina y la limpieza debe continuar.
+      }
+      await limpiarEstadoLocal();
+      queryClient.clear();
+      router.replace("/login");
+    } finally {
+      setCerrando(false);
+    }
+  }, [queryClient, router]);
+
+  return { cerrarSesion, cerrando };
+}

--- a/src/lib/limpiarEstadoLocal.ts
+++ b/src/lib/limpiarEstadoLocal.ts
@@ -1,0 +1,45 @@
+import {
+  actualizarAppBadge,
+  limpiarNotificados,
+} from "@/lib/notificacionesVencimiento";
+import { clearQueue } from "@/lib/outbox/outbox";
+import { limpiarCachePersistido } from "@/lib/queryPersister";
+import { useRecentsStore } from "@/store/recents";
+
+/**
+ * Limpieza local completa al cerrar sesión (docs/SPECMULTIUSER.md §3.2).
+ * El dispositivo de la tienda es potencialmente compartido: es un requisito
+ * de privacidad, no polish. Única fuente de la lista — logout y "cambio de
+ * usuario detectado" deben pasar por acá.
+ *
+ * No borra preferencias de dispositivo sin datos (gondolapp-theme,
+ * gondolapp-ui, flag de notificaciones).
+ */
+export async function limpiarEstadoLocal(): Promise<void> {
+  // Datos en IndexedDB: cache de queries + cola offline.
+  await Promise.all([limpiarCachePersistido(), clearQueue()]);
+
+  // Recientes/frecuentes (nombres de productos de la tienda).
+  useRecentsStore.setState({ entries: {} });
+  useRecentsStore.persist.clearStorage();
+
+  // Registro de vencimientos ya notificados + badge del ícono.
+  limpiarNotificados();
+  actualizarAppBadge(0);
+
+  // Caches del service worker que guardan respuestas con datos (/api/*).
+  // Los GETs de Supabase no entran al SW (ver public/sw.js), esto purga
+  // lo que sí se cachea.
+  if (typeof caches !== "undefined") {
+    const claves = await caches.keys();
+    await Promise.all(
+      claves
+        .filter(
+          (clave) =>
+            clave.startsWith("gondolapp-dynamic-") ||
+            clave.startsWith("gondolapp-api-")
+        )
+        .map((clave) => caches.delete(clave))
+    );
+  }
+}

--- a/src/lib/notificacionesVencimiento.ts
+++ b/src/lib/notificacionesVencimiento.ts
@@ -98,6 +98,16 @@ export function guardarNotificados(registro: RegistroNotificados): void {
   }
 }
 
+/** Borra el registro de notificados (logout, spec §3.2). */
+export function limpiarNotificados(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // sin acceso a storage: nada que borrar
+  }
+}
+
 /** iOS Safari solo expone Notification con la PWA instalada (16.4+). */
 export function soportaNotificaciones(): boolean {
   return typeof window !== "undefined" && "Notification" in window;

--- a/src/lib/outbox/__tests__/outbox.test.ts
+++ b/src/lib/outbox/__tests__/outbox.test.ts
@@ -94,6 +94,39 @@ describe("processQueue", () => {
     expect(await countPending()).toBe(1);
   });
 
+  it("corta la corrida sin descartar ante un JWT expirado (PGRST301/401)", async () => {
+    const { enqueueOperation, processQueue, countPending } = await import(
+      "@/lib/outbox/outbox"
+    );
+    const { ejecutarOperacion } = await import("@/lib/outbox/executors");
+    vi.mocked(ejecutarOperacion).mockRejectedValue(
+      Object.assign(new Error("JWT expired"), { code: "PGRST301" })
+    );
+
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-1" });
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-2" });
+    await processQueue();
+
+    // Nada se descarta: el trabajo offline se reintenta tras el refresh.
+    expect(await countPending()).toBe(2);
+    expect(ejecutarOperacion).toHaveBeenCalledTimes(1);
+  });
+
+  it("corta la corrida ante un 401 sin código PGRST", async () => {
+    const { enqueueOperation, processQueue, countPending } = await import(
+      "@/lib/outbox/outbox"
+    );
+    const { ejecutarOperacion } = await import("@/lib/outbox/executors");
+    vi.mocked(ejecutarOperacion).mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), { status: 401 })
+    );
+
+    await enqueueOperation("reposicion.eliminarItem", { id: "item-1" });
+    await processQueue();
+
+    expect(await countPending()).toBe(1);
+  });
+
   it("descarta una operación con error de datos (no de red) y sigue con el resto", async () => {
     const { enqueueOperation, processQueue, countPending } = await import(
       "@/lib/outbox/outbox"

--- a/src/lib/outbox/outbox.ts
+++ b/src/lib/outbox/outbox.ts
@@ -35,7 +35,7 @@ export async function countPending(): Promise<number> {
   return (await readQueue()).length;
 }
 
-/** Solo para tests/depuración: vacía la cola sin ejecutar nada. */
+/** Vacía la cola sin ejecutar nada (logout vía limpiarEstadoLocal, tests). */
 export async function clearQueue(): Promise<void> {
   await del(QUEUE_KEY, outboxStore);
   useOutboxStore.getState().setPendingCount(0);
@@ -52,6 +52,25 @@ export function isNetworkError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Errores de autenticación transitorios: JWT vencido al volver online,
+ * sesión todavía sin refrescar. La operación es válida y va a funcionar
+ * tras el refresh de autoRefreshToken — debe cortar la corrida como un
+ * error de red, NUNCA descartarse (perdería trabajo offline en silencio,
+ * spec §4.3). Un 403 de RLS en cambio es error de datos: reintentar no
+ * lo arregla y sí debe descartarse.
+ */
+export function esErrorDeAuthReintentable(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: unknown; status?: unknown; message?: unknown };
+  if (e.code === "PGRST301") return true;
+  if (e.status === 401) return true;
+  return (
+    typeof e.message === "string" &&
+    /jwt (expired|invalid)|token (is )?expired/i.test(e.message)
+  );
+}
+
 let procesando = false;
 
 /**
@@ -60,10 +79,10 @@ let procesando = false;
  * las operaciones siguientes en la misma corrida que referencien ese mismo
  * item (por ejemplo: crear offline → cambiar cantidad offline, en ese orden).
  *
- * Si una operación falla por red, la corrida se corta ahí (la cola queda
- * intacta) para reintentar más tarde. Si falla por otra razón (dato
- * inválido, item ya no existe), se descarta esa operación puntual para no
- * bloquear el resto de la cola.
+ * Si una operación falla por red o por sesión vencida (401/PGRST301), la
+ * corrida se corta ahí (la cola queda intacta) para reintentar más tarde.
+ * Si falla por otra razón (dato inválido, item ya no existe), se descarta
+ * esa operación puntual para no bloquear el resto de la cola.
  */
 export async function processQueue(): Promise<void> {
   if (procesando || !isOnline()) return;
@@ -83,8 +102,9 @@ export async function processQueue(): Promise<void> {
         }
         await writeQueue(resto);
       } catch (err) {
-        if (isNetworkError(err)) break;
-        // Error de datos (no de red): se descarta para no bloquear la cola.
+        if (isNetworkError(err) || esErrorDeAuthReintentable(err)) break;
+        // Error de datos (no de red ni de auth): se descarta para no
+        // bloquear la cola.
         await writeQueue(resto);
       }
     }

--- a/src/lib/queryPersister.ts
+++ b/src/lib/queryPersister.ts
@@ -1,5 +1,5 @@
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
-import { createStore, del, get, set } from "idb-keyval";
+import { clear, createStore, del, get, set } from "idb-keyval";
 
 /**
  * Persistencia del cache de React Query en IndexedDB, para que las listas
@@ -56,6 +56,11 @@ export function esQueryPersistible(queryKey: readonly unknown[]): boolean {
     (queryKey[0] === "catalogo" && queryKey[1] === "completo") ||
     (queryKey[0] === "producto" && queryKey[1] === "ean")
   );
+}
+
+/** Vacía el cache persistido (logout / cambio de usuario, spec §3.2). */
+export async function limpiarCachePersistido(): Promise<void> {
+  if (store) await clear(store);
 }
 
 export const MAX_AGE_CACHE_MS = 24 * 60 * 60 * 1000;

--- a/src/lib/rutasPublicas.ts
+++ b/src/lib/rutasPublicas.ts
@@ -1,0 +1,21 @@
+/**
+ * Rutas navegables sin sesión — única fuente para el gate del proxy (Edge)
+ * y el gate client-side (AuthProvider). /sw.js y /offline.html son
+ * críticas: el matcher del proxy no excluye .js/.html y sin ellas el
+ * service worker no podría registrarse ni precachear estando deslogueado.
+ */
+export const RUTAS_PUBLICAS = [
+  "/login",
+  "/registro",
+  "/recuperar",
+  "/restablecer",
+  "/unirse",
+  "/sw.js",
+  "/offline.html",
+] as const;
+
+export function esRutaPublica(pathname: string): boolean {
+  return RUTAS_PUBLICAS.some(
+    (ruta) => pathname === ruta || pathname.startsWith(`${ruta}/`)
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { createBrowserClient } from "@supabase/ssr";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -9,4 +9,12 @@ if (!supabaseUrl || !supabaseAnonKey) {
   );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+/**
+ * Cliente del browser. La sesión vive en cookies (@supabase/ssr) para que
+ * el proxy y los route handlers la lean; se restaura sin red en arranque
+ * frío offline, igual que localStorage (docs/SPECMULTIUSER.md §3.1).
+ * En el servidor este singleton es solo el default de firma de los
+ * servicios: los route handlers pasan el cliente por-request de
+ * supabaseServer.ts.
+ */
+export const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,34 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+/**
+ * Cliente Supabase por-request para route handlers: lee la sesión del
+ * usuario desde las cookies del request, así RLS aplica con su JWT (y no
+ * como `anon`, que quedó sin acceso desde la migración 0012).
+ */
+export async function crearClienteServidor() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          // En route handlers sí se puede escribir (refresh de token);
+          // si el contexto no lo permite, el proxy ya refresca la sesión.
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            /* contexto de solo lectura */
+          }
+        },
+      },
+    }
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,5 @@
+import { esRutaPublica } from "@/lib/rutasPublicas";
+import { createServerClient } from "@supabase/ssr";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { NextRequest, NextResponse } from "next/server";
@@ -65,13 +67,78 @@ const createLimiter = redis
     })
   : null;
 
+/**
+ * Refresca la sesión leyendo cookies (@supabase/ssr) y redirige a /login
+ * en rutas protegidas sin usuario. Best-effort a propósito (spec §3.1):
+ * en arranque offline el SW sirve el shell sin pasar por acá, y si Auth no
+ * responde se deja pasar — el gate real de UX es client-side (AuthProvider).
+ */
+async function gateDeSesion(request: NextRequest): Promise<NextResponse> {
+  const pathname = request.nextUrl.pathname;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return NextResponse.next({ request });
+
+  const redirigirALogin = () => {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    url.search = "";
+    return NextResponse.redirect(url);
+  };
+
+  // Sin cookie de Supabase no hay sesión que refrescar: redirect directo,
+  // sin pagar el round-trip a Auth.
+  const hayCookieDeSesion = request.cookies
+    .getAll()
+    .some((c) => c.name.startsWith("sb-"));
+  if (!hayCookieDeSesion) {
+    return esRutaPublica(pathname)
+      ? NextResponse.next({ request })
+      : redirigirALogin();
+  }
+
+  let response = NextResponse.next({ request });
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) =>
+          request.cookies.set(name, value)
+        );
+        response = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          response.cookies.set(name, value, options)
+        );
+      },
+    },
+  });
+
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user && !esRutaPublica(pathname)) {
+      const redirect = redirigirALogin();
+      // Conservar las cookies del refresh (p.ej. limpieza de una sesión inválida).
+      response.cookies.getAll().forEach((cookie) => redirect.cookies.set(cookie));
+      return redirect;
+    }
+  } catch {
+    // Auth inalcanzable: dejar pasar (best-effort).
+  }
+  return response;
+}
+
 // 🔄 Nueva convención Next.js 16: export default (antes era "export async function middleware")
 export default async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  // Solo aplicar rate limiting a API routes
+  // Páginas: gate de sesión. API routes: rate limiting (el 401 lo maneja
+  // cada route handler con su cliente por-request).
   if (!pathname.startsWith("/api/")) {
-    return addSecurityHeaders(NextResponse.next());
+    return addSecurityHeaders(await gateDeSesion(request));
   }
 
   // Obtener IP del cliente

--- a/supabase/migrations/0012_tiendas_y_backfill.sql
+++ b/supabase/migrations/0012_tiendas_y_backfill.sql
@@ -1,0 +1,182 @@
+-- Fase 1 multi-tienda (docs/SPECMULTIUSER.md §1.1, §1.4 y Roadmap):
+-- tablas de organización, tienda inicial con UUID fijo, tienda_id en las 8
+-- tablas de datos (DEFAULT + backfill + not null + índices) y RLS
+-- intermedio: anon queda sin acceso, authenticated mantiene using(true)
+-- hasta el scoping por tienda de la Fase 2.
+--
+-- ⚠️ Deploy coordinado (riesgo "corte de anon" de la spec): al aplicar esta
+-- migración, toda PWA sin login recibe 401/403. El usuario real debe
+-- loguearse y recargar la app el mismo día.
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Tablas nuevas
+-- ─────────────────────────────────────────────────────────────────────────
+
+create table tiendas (
+  id uuid primary key default gen_random_uuid(),
+  nombre text not null check (length(trim(nombre)) between 1 and 80),
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger trg_tiendas_updated_at
+  before update on tiendas
+  for each row
+  execute function set_updated_at();
+
+create table tienda_miembros (
+  tienda_id uuid not null references tiendas(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  rol text not null default 'empleado' check (rol in ('admin', 'empleado')),
+  created_at timestamptz not null default now(),
+  primary key (tienda_id, user_id)
+);
+create index idx_tienda_miembros_user_id on tienda_miembros (user_id);
+
+create table tienda_invitaciones (
+  id uuid primary key default gen_random_uuid(),
+  tienda_id uuid not null references tiendas(id) on delete cascade,
+  codigo text not null unique,
+  rol text not null default 'empleado' check (rol in ('admin', 'empleado')),
+  creado_por uuid references auth.users(id) on delete set null,
+  expira_at timestamptz not null default now() + interval '7 days',
+  max_usos int not null default 1 check (max_usos > 0),
+  usos int not null default 0,
+  revocada boolean not null default false,
+  created_at timestamptz not null default now()
+);
+create index idx_tienda_invitaciones_tienda_id on tienda_invitaciones (tienda_id);
+
+-- RLS activo sin policies = acceso denegado para anon y authenticated.
+-- Las policies reales (helpers mis_tiendas(), roles) llegan en la Fase 2;
+-- hasta entonces, la única gestión es manual vía service_role/dashboard.
+alter table tiendas enable row level security;
+alter table tienda_miembros enable row level security;
+alter table tienda_invitaciones enable row level security;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Tienda inicial (UUID fijo, referenciado por los DEFAULT de abajo)
+-- ─────────────────────────────────────────────────────────────────────────
+
+insert into tiendas (id, nombre)
+values ('a9defb27-54dd-4cb8-853f-2c901f8365dd', 'Mi Tienda');
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. tienda_id en las 8 tablas de datos: DEFAULT + backfill + not null.
+--    El DEFAULT queda vigente durante TODA la Fase 1 porque en esta fase
+--    ningún cliente envía tienda_id (el scoping y los triggers de
+--    derivación llegan en la Fase 2, que además elimina el DEFAULT).
+-- ─────────────────────────────────────────────────────────────────────────
+
+alter table producto_bases
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table producto_variantes
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table categoria_atributos
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table items_reposicion
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table listas_reposicion_historial
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table items_reposicion_historial
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table items_vencimiento
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+alter table items_vencimiento_historial
+  add column tienda_id uuid references tiendas(id) on delete restrict
+  default 'a9defb27-54dd-4cb8-853f-2c901f8365dd';
+
+-- Backfill explícito: ADD COLUMN con DEFAULT ya rellena las filas
+-- existentes en Postgres moderno, pero el update es idempotente y deja la
+-- intención auditable.
+update producto_bases set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update producto_variantes set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update categoria_atributos set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update items_reposicion set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update listas_reposicion_historial set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update items_reposicion_historial set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update items_vencimiento set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+update items_vencimiento_historial set tienda_id = 'a9defb27-54dd-4cb8-853f-2c901f8365dd' where tienda_id is null;
+
+alter table producto_bases alter column tienda_id set not null;
+alter table producto_variantes alter column tienda_id set not null;
+alter table categoria_atributos alter column tienda_id set not null;
+alter table items_reposicion alter column tienda_id set not null;
+alter table listas_reposicion_historial alter column tienda_id set not null;
+alter table items_reposicion_historial alter column tienda_id set not null;
+alter table items_vencimiento alter column tienda_id set not null;
+alter table items_vencimiento_historial alter column tienda_id set not null;
+
+-- Índices de soporte para las policies por tienda (los compuestos de hot
+-- paths llegan con el scoping real en la Fase 2).
+create index idx_producto_bases_tienda_id on producto_bases (tienda_id);
+create index idx_producto_variantes_tienda_id on producto_variantes (tienda_id);
+create index idx_categoria_atributos_tienda_id on categoria_atributos (tienda_id);
+create index idx_items_reposicion_tienda_id on items_reposicion (tienda_id);
+create index idx_listas_reposicion_historial_tienda_id on listas_reposicion_historial (tienda_id);
+create index idx_items_reposicion_historial_tienda_id on items_reposicion_historial (tienda_id);
+create index idx_items_vencimiento_tienda_id on items_vencimiento (tienda_id);
+create index idx_items_vencimiento_historial_tienda_id on items_vencimiento_historial (tienda_id);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 4. RLS intermedio: fuera anon, authenticated sigue con using(true).
+--    Las 8 policies allow_all_anon: 7 de la migración 0002 + la de
+--    categoria_atributos de la 0008 (§M7 del análisis: enumerar ambas).
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop policy "allow_all_anon" on producto_bases;
+drop policy "allow_all_anon" on producto_variantes;
+drop policy "allow_all_anon" on categoria_atributos;
+drop policy "allow_all_anon" on items_reposicion;
+drop policy "allow_all_anon" on listas_reposicion_historial;
+drop policy "allow_all_anon" on items_reposicion_historial;
+drop policy "allow_all_anon" on items_vencimiento;
+drop policy "allow_all_anon" on items_vencimiento_historial;
+
+create policy "allow_all_authenticated" on producto_bases
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on producto_variantes
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on categoria_atributos
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on items_reposicion
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on listas_reposicion_historial
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on items_reposicion_historial
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on items_vencimiento
+  for all to authenticated using (true) with check (true);
+create policy "allow_all_authenticated" on items_vencimiento_historial
+  for all to authenticated using (true) with check (true);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 5. Las 5 RPCs SECURITY DEFINER bypasean RLS, así que cortar anon en las
+--    tablas no alcanza: sin este revoke, anon seguiría operando a través
+--    de ellas. (Siguen siendo DEFINER hasta la conversión a INVOKER de la
+--    Fase 2.) EXECUTE es por default de PUBLIC: hay que revocar ambos.
+-- ─────────────────────────────────────────────────────────────────────────
+
+revoke execute on function agregar_item_reposicion(uuid, integer) from public, anon;
+revoke execute on function guardar_lista_reposicion() from public, anon;
+revoke execute on function retirar_item_vencimiento(uuid) from public, anon;
+revoke execute on function retirar_items_vencimiento(uuid[]) from public, anon;
+revoke execute on function obtener_estadisticas_vencimiento(timestamptz, timestamptz) from public, anon;
+
+grant execute on function agregar_item_reposicion(uuid, integer) to authenticated, service_role;
+grant execute on function guardar_lista_reposicion() to authenticated, service_role;
+grant execute on function retirar_item_vencimiento(uuid) to authenticated, service_role;
+grant execute on function retirar_items_vencimiento(uuid[]) to authenticated, service_role;
+grant execute on function obtener_estadisticas_vencimiento(timestamptz, timestamptz) to authenticated, service_role;
+
+-- Post-deploy manual (spec §1.4): tras el primer login del usuario real,
+--   insert into tienda_miembros (tienda_id, user_id, rol)
+--   values ('a9defb27-54dd-4cb8-853f-2c901f8365dd', '<uid>', 'admin');


### PR DESCRIPTION
## 📝 Descripción

Fase 1 del roadmap de `docs/SPECMULTIUSER.md` — auth + tienda única implícita:

- **Clientes `@supabase/ssr`**: `src/lib/supabase.ts` pasa a `createBrowserClient` (sesión en cookies, restaurable offline) y `src/lib/supabaseServer.ts` da el cliente por-request de los route handlers.
- **Migración `supabase/migrations/0012_tiendas_y_backfill.sql`**: tablas `tiendas`/`tienda_miembros`/`tienda_invitaciones` (RLS activo sin policies hasta la Fase 2), tienda inicial con UUID fijo, `tienda_id` con `DEFAULT` + backfill + `NOT NULL` + índices en las 8 tablas de datos, RLS intermedio (se eliminan las 8 policies `anon` — las 7 de la 0002 y la de `categoria_atributos` de la 0008 — y `authenticated` mantiene `using(true)`), y `REVOKE EXECUTE` a `public, anon` en las 5 RPCs `SECURITY DEFINER` (sin esto, `anon` seguiría operando a través de ellas).
- **Gates de sesión**: refresh + redirect a `/login` en `src/proxy.ts` (con `/sw.js` y `/offline.html` públicas — el matcher no excluye `.js`/`.html` y sin eso el SW no se registraría deslogueado) y gate client-side en `AuthProvider` (por fuera de `QueryProvider`), que con sesión local nunca bloquea el shell offline.
- **Pantallas**: `/login`, `/registro`, `/recuperar`, `/restablecer` con el sistema de tokens existente.
- **Logout con `limpiarEstadoLocal()`** (requisito de privacidad en dispositivo compartido, spec §3.2): aviso de outbox pendiente → signOut → query cache IDB + cola offline + recientes + registro de notificados + badge + caches `gondolapp-dynamic-*`/`gondolapp-api-*` del SW → `/login`. Botón en el header del home.
- **Service worker v3** (spec §6): los GETs de `*.supabase.co` ya no entran a Cache Storage; el bump de versión fuerza el ciclo de update (el prompt ya existía en `usePWA`).
- **Dos adelantos de Fase 2, necesarios en esta fase**: (1) gate 401 + cliente por-request en `/api/productos/crear-manual` y `/api/productos/parsear` — con el corte de `anon` los routes operarían como `anon` y romperían; (2) el outbox clasifica 401/`PGRST301`/JWT expired como reintenables (cortan la corrida sin descartar) — los JWTs que pueden vencer existen desde esta fase.

## 🎯 Tipo de cambio

- [x] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [x] 💥 Breaking change (cambio que rompe compatibilidad)

## 🔗 Issue relacionado

Roadmap de `docs/SPECMULTIUSER.md` (Fase 1).

## 🧪 Testing

- [x] 168 tests verdes (166 existentes sin modificar + 2 nuevos del outbox)
- [x] `tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos (las 10 warnings son preexistentes)
- [x] `next build` OK (4 páginas estáticas nuevas + middleware)
- [ ] Funciona offline (PWA) — requiere prueba manual post-deploy
- [ ] Probado en móvil — requiere prueba manual post-deploy

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado el código en áreas difíciles de entender
- [x] Mis cambios no generan warnings nuevos
- [x] He actualizado la documentación correspondiente
- [x] Los tests existentes pasan correctamente

## 📸 Screenshots (si aplica)

N/A (pantallas nuevas de login/registro/recuperación con el design system existente).

## 🎯 Instrucciones de testing

1. Ensayar `0012_tiendas_y_backfill.sql` en el staging con dump de producción **antes** de tocar producción.
2. En Supabase Auth (dashboard): deshabilitar "Allow new users to sign up", verificar que time-box/inactivity timeout están off, configurar SMTP custom (Resend) para el reset de contraseña.
3. Aplicar la migración + deploy del código **el mismo día**, coordinado con el usuario real: crear su cuenta desde el dashboard, login, y correr el alta manual de membresía que está comentada al final de la migración.
4. Verificar: requests anónimas a PostgREST devuelven 0 filas/error en las 8 tablas; la app opera igual que antes tras loguearse; el reset de contraseña llega por email; el arranque offline con sesión funciona; ningún GET de `*.supabase.co` aparece en Cache Storage.

## 📌 Notas adicionales

⚠️ **Deploy coordinado obligatorio** (riesgo 🔴 "corte de anon" de la spec): al aplicar la migración 0012, toda PWA sin login recibe 401/403 en todo. La migración **no** se aplica automáticamente con este merge — es un paso operativo separado, y hasta que se aplique, el código nuevo convive con la base vieja sin romperla (el gate de login ya funciona; los datos siguen accesibles para `authenticated`... y para `anon` hasta la migración).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW)_