### PR TITLE
Fase 2 multi-tienda: scoping real por tienda (RLS por membresía + cliente scoped)

### DIFF
--- a/.github/workflows/integracion.yml
+++ b/.github/workflows/integracion.yml
@@ -1,0 +1,49 @@
+name: Integración - Aislamiento RLS
+
+# Corre la suite de integración contra un stack real de Supabase
+# (docs/SPECMULTIUSER.md §2.4): levanta Postgres + Auth + PostgREST en el
+# runner, aplica supabase/migrations/ y ejecuta src/tests/integration/.
+# Es el gate de la Fase 2 multi-tienda: ninguna policy floja pasa a main.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  aislamiento:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Levantar stack local (aplica supabase/migrations/)
+        run: supabase start
+
+      - name: Exportar keys del stack local
+        run: |
+          eval "$(supabase status --output env)"
+          {
+            echo "SUPABASE_URL=$API_URL"
+            echo "SUPABASE_ANON_KEY=$ANON_KEY"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY"
+          } >> "$GITHUB_ENV"
+
+      - name: Suite de integración (aislamiento RLS)
+        run: npm run test:integration

--- a/src/app/QueryProvider.tsx
+++ b/src/app/QueryProvider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import {
   esQueryPersistible,
   MAX_AGE_CACHE_MS,
@@ -7,10 +8,16 @@ import {
 } from "@/lib/queryPersister";
 import { QueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
-import { useState } from "react";
+import { useMemo } from "react";
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(
+  const { user, tiendaActiva, cargando } = useAuth();
+
+  // Identidad del cache: cambiar de usuario o de tienda descarta el cache
+  // restaurado (buster) y arranca un QueryClient limpio (key del provider).
+  const identidad = `${user?.id ?? "anon"}:${tiendaActiva ?? "sin-tienda"}`;
+
+  const queryClient = useMemo(
     () =>
       new QueryClient({
         defaultOptions: {
@@ -22,20 +29,24 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             gcTime: MAX_AGE_CACHE_MS,
           },
         },
-      })
+      }),
+    [identidad]
   );
+
+  // La sesión inicial se resuelve desde la cookie local (milisegundos,
+  // también offline); no montar el persister con la identidad equivocada.
+  if (cargando) return null;
 
   return (
     <PersistQueryClientProvider
+      key={identidad}
       client={queryClient}
       persistOptions={{
         persister: queryPersister,
         maxAge: MAX_AGE_CACHE_MS,
-        // v3: ProductoVariante pasó de tipo/tamano/sabor a atributos jsonb;
-        // el bump descarta caches con el shape viejo (la rehidratación no
-        // pasa por el mapper, así que el `?? {}` defensivo no alcanza).
-        // (v2 había descartado los Map serializados como {} de v1.)
-        buster: "v3",
+        // v4: cache aislado por identidad (multi-tienda, spec §4.2).
+        // (v3 descartaba el shape viejo de atributos; v2 los Map de v1.)
+        buster: `v4:${identidad}`,
         dehydrateOptions: {
           shouldDehydrateQuery: (query) =>
             query.state.status === "success" &&

--- a/src/app/api/productos/crear-manual/route.ts
+++ b/src/app/api/productos/crear-manual/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body: CrearProductoDTO = await request.json();
+    const body: CrearProductoDTO & { tiendaId?: unknown } = await request.json();
 
     if (!body.ean || !body.productoBase?.nombre || !body.productoBase?.marca) {
       return NextResponse.json(
@@ -68,6 +68,15 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    // Tienda activa del cliente: producto_bases es tabla raíz y necesita
+    // tienda_id explícito; la membresía la valida el WITH CHECK de RLS.
+    if (typeof body.tiendaId !== "string" || !body.tiendaId) {
+      return NextResponse.json(
+        { success: false, error: "Falta tiendaId" },
+        { status: 400 }
+      );
+    }
+    const tiendaId = body.tiendaId;
 
     const atributosCrudos = body.variante?.atributos ?? {};
     if (!esObjetoPlanoDeStrings(atributosCrudos)) {
@@ -81,7 +90,7 @@ export async function POST(request: NextRequest) {
     // perder el alta por un fallo del lookup sería peor que un valor sin canon.
     let atributos = atributosCrudos;
     try {
-      const defs = await obtenerDefinicionesAtributos(supabase);
+      const defs = await obtenerDefinicionesAtributos(tiendaId, supabase);
       const categoria = body.productoBase.categoria?.trim();
       const defsAplicables =
         (categoria && defs.porCategoria[categoria]) || defs.default;
@@ -91,6 +100,7 @@ export async function POST(request: NextRequest) {
     }
 
     const producto = await crearProductoManual(
+      tiendaId,
       {
         ...body,
         variante: { ...body.variante, atributos },
@@ -148,9 +158,25 @@ export async function GET() {
       );
     }
 
+    // Endpoint deprecado sin body: usa la primera membresía del usuario.
+    const { data: membresia } = await supabase
+      .from("tienda_miembros")
+      .select("tienda_id")
+      .limit(1)
+      .maybeSingle();
+    if (!membresia) {
+      return NextResponse.json({
+        success: true,
+        marcas: [],
+        categorias: [],
+        atributosDefault: [],
+        atributosPorCategoria: {},
+      });
+    }
+
     const [{ marcas, categorias }, defs] = await Promise.all([
-      obtenerMarcasYCategorias(supabase),
-      obtenerDefinicionesAtributos(supabase),
+      obtenerMarcasYCategorias(membresia.tienda_id, supabase),
+      obtenerDefinicionesAtributos(membresia.tienda_id, supabase),
     ]);
     return NextResponse.json({
       success: true,

--- a/src/app/api/productos/parsear/route.ts
+++ b/src/app/api/productos/parsear/route.ts
@@ -34,8 +34,9 @@ export async function POST(request: NextRequest) {
   }
 
   let texto: unknown;
+  let tiendaId: unknown;
   try {
-    ({ texto } = await request.json());
+    ({ texto, tiendaId } = await request.json());
   } catch {
     return NextResponse.json(
       { success: false, error: "Body inválido" },
@@ -43,6 +44,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  if (typeof tiendaId !== "string" || !tiendaId) {
+    return NextResponse.json(
+      { success: false, error: "Falta tiendaId" },
+      { status: 400 }
+    );
+  }
   if (typeof texto !== "string" || !texto.trim()) {
     return NextResponse.json(
       { success: false, error: "Falta el texto del producto" },
@@ -57,13 +64,13 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const parsed = await parsearProducto(texto.trim(), supabase);
+    const parsed = await parsearProducto(texto.trim(), tiendaId, supabase);
 
     // Preview del nombre con el mismo orden de claves que usará el trigger
     // de BD al crear (definición de la categoría, o default global).
     let orden: readonly string[] = ORDEN_ATRIBUTOS_DEFAULT;
     try {
-      const defs = await obtenerDefinicionesAtributos(supabase);
+      const defs = await obtenerDefinicionesAtributos(tiendaId, supabase);
       const categoria = parsed.productoBase.categoria;
       const defsAplicables =
         (categoria && defs.porCategoria[categoria]) ||

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { setUsuarioOutbox } from "@/lib/outbox/outbox";
 import { esRutaPublica } from "@/lib/rutasPublicas";
 import { supabase } from "@/lib/supabase";
+import { RolTienda, useSesionStore } from "@/store/sesion";
 import type { User } from "@supabase/supabase-js";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -15,11 +17,18 @@ interface AuthContextValue {
   user: User | null;
   /** true mientras se resuelve la sesión inicial (lectura local, sin red). */
   cargando: boolean;
+  /** Tienda activa del usuario (única membresía en el caso típico). En
+   * arranque offline sale del valor persistido; online se reconcilia contra
+   * tienda_miembros. */
+  tiendaActiva: string | null;
+  rol: RolTienda | null;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   cargando: true,
+  tiendaActiva: null,
+  rol: null,
 });
 
 export function useAuth(): AuthContextValue {
@@ -27,7 +36,7 @@ export function useAuth(): AuthContextValue {
 }
 
 /**
- * Sesión de Supabase por contexto + gate client-side.
+ * Sesión de Supabase por contexto + gate client-side + tienda activa.
  *
  * El gate del proxy es best-effort (en arranque offline el SW sirve el
  * shell sin pasar por el Edge): este es el gate real de UX. getSession()
@@ -35,13 +44,20 @@ export function useAuth(): AuthContextValue {
  * nunca se bloquea — aunque el access token esté vencido, las lecturas
  * salen del cache IDB y las escrituras van al outbox (spec §3.1).
  *
- * Va por fuera de QueryProvider: en la Fase 2 el buster del persister y
- * las query keys necesitan la identidad antes de montar los providers de
- * datos.
+ * Va por fuera de QueryProvider: el buster del persister y las query keys
+ * dependen de la identidad (user + tienda activa) antes de montar los
+ * providers de datos.
  */
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [cargando, setCargando] = useState(true);
+  // Arranque con el valor persistido: offline es la única fuente posible.
+  const [tiendaActiva, setTiendaActiva] = useState<string | null>(
+    () => useSesionStore.getState().tiendaActivaId
+  );
+  const [rol, setRol] = useState<RolTienda | null>(
+    () => useSesionStore.getState().rol
+  );
   const pathname = usePathname();
   const router = useRouter();
 
@@ -67,6 +83,35 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  // Resolver la membresía cuando hay usuario; sin red queda el persistido.
+  useEffect(() => {
+    setUsuarioOutbox(user?.id ?? null);
+    if (!user) {
+      setTiendaActiva(null);
+      setRol(null);
+      return;
+    }
+
+    let activo = true;
+    supabase
+      .from("tienda_miembros")
+      .select("tienda_id, rol")
+      .then(({ data, error }) => {
+        if (!activo || error || !data) return;
+        const persistida = useSesionStore.getState().tiendaActivaId;
+        const elegida =
+          data.find((m) => m.tienda_id === persistida) ?? data[0] ?? null;
+        const tiendaId = elegida?.tienda_id ?? null;
+        const rolElegido = (elegida?.rol as RolTienda | undefined) ?? null;
+        setTiendaActiva(tiendaId);
+        setRol(rolElegido);
+        useSesionStore.getState().setTienda(tiendaId, rolElegido);
+      });
+    return () => {
+      activo = false;
+    };
+  }, [user]);
+
   useEffect(() => {
     if (cargando || user) return;
     if (!esRutaPublica(pathname)) router.replace("/login");
@@ -79,7 +124,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, cargando }}>
+    <AuthContext.Provider value={{ user, cargando, tiendaActiva, rol }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/components/CatalogoSyncProvider.tsx
+++ b/src/components/CatalogoSyncProvider.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
+import { useAuth } from "@/components/AuthProvider";
+import { catalogoCompletoKey } from "@/lib/queryKeys";
 import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 /**
- * Mantiene el catálogo completo (bases + variantes + definiciones) fresco
- * en cache: prefetch al montar (si hay conexión) y refresh en cada evento
- * `online`, para que escanear/buscar offline use datos recientes en vez de
- * esperar al primer miss de useCatalogoCompleto.
+ * Mantiene el catálogo completo de la tienda activa (bases + variantes +
+ * definiciones) fresco en cache: prefetch al montar (si hay conexión) y
+ * refresh en cada evento `online`, para que escanear/buscar offline use
+ * datos recientes en vez de esperar al primer miss de useCatalogoCompleto.
  *
  * Separado de OutboxProvider a propósito: ese sincroniza la cola de
  * mutaciones offline, esto sincroniza una lectura de catálogo —
@@ -18,19 +19,21 @@ import { useEffect } from "react";
  */
 export default function CatalogoSyncProvider() {
   const queryClient = useQueryClient();
+  const { tiendaActiva } = useAuth();
 
   useEffect(() => {
+    if (!tiendaActiva) return;
     const sincronizar = () =>
       queryClient.prefetchQuery({
-        queryKey: CATALOGO_COMPLETO_KEY,
-        queryFn: obtenerCatalogoCompleto,
+        queryKey: catalogoCompletoKey(tiendaActiva),
+        queryFn: () => obtenerCatalogoCompleto(tiendaActiva),
         staleTime: 30 * 60_000,
       });
 
     if (navigator.onLine) sincronizar();
     window.addEventListener("online", sincronizar);
     return () => window.removeEventListener("online", sincronizar);
-  }, [queryClient]);
+  }, [queryClient, tiendaActiva]);
 
   return null;
 }

--- a/src/components/OutboxProvider.tsx
+++ b/src/components/OutboxProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { countPending, processQueue } from "@/lib/outbox/outbox";
+import { supabase } from "@/lib/supabase";
 import { useOutboxStore } from "@/store/outbox";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
@@ -20,10 +21,15 @@ export default function OutboxProvider() {
     const sincronizar = async () => {
       const antes = await countPending();
       if (antes === 0) return;
+      // getSession refresca el access token si está por vencer; sin sesión
+      // no se procesa (la cola queda intacta para el próximo login).
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
       await processQueue();
       const despues = await countPending();
-      queryClient.invalidateQueries({ queryKey: ["reposicion"] });
-      queryClient.invalidateQueries({ queryKey: ["vencimiento"] });
+      // Prefijo ["tienda"]: invalida las listas de todas las tiendas (las
+      // keys llevan tienda desde la Fase 2).
+      queryClient.invalidateQueries({ queryKey: ["tienda"] });
       if (despues < antes) {
         toast.success(
           antes - despues === 1

--- a/src/components/scanner/ManualProductSheet.tsx
+++ b/src/components/scanner/ManualProductSheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import { BottomSheet } from "@/components/ui/BottomSheet";
 import { useMarcasCategorias } from "@/hooks/useMarcasCategorias";
 import { ProductoEscaneado } from "@/hooks/useScanProduct";
@@ -44,6 +45,7 @@ export function ManualProductSheet({
   onCreated,
   onClose,
 }: ManualProductSheetProps) {
+  const { tiendaActiva } = useAuth();
   const [modo, setModo] = useState<Modo>("input");
   const [texto, setTexto] = useState("");
   const [parseando, setParseando] = useState(false);
@@ -108,7 +110,7 @@ export function ManualProductSheet({
       const response = await fetch("/api/productos/parsear", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ texto: texto.trim() }),
+        body: JSON.stringify({ texto: texto.trim(), tiendaId: tiendaActiva }),
       });
       const result = await response.json();
       if (!result.success || !result.parsed?.productoBase?.nombre) {
@@ -132,7 +134,7 @@ export function ManualProductSheet({
       const response = await fetch("/api/productos/crear-manual", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(dto),
+        body: JSON.stringify({ ...dto, tiendaId: tiendaActiva }),
       });
       const result = await response.json();
 

--- a/src/components/scanner/ScanFlow.tsx
+++ b/src/components/scanner/ScanFlow.tsx
@@ -8,7 +8,8 @@ import {
   useEliminarReposicionItemDirecto,
 } from "@/hooks/useReposicion";
 import { useAgregarVencimientoItem } from "@/hooks/useVencimiento";
-import { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
+import { useAuth } from "@/components/AuthProvider";
+import { catalogoCompletoKey, SIN_TIENDA } from "@/lib/queryKeys";
 import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useRecentsStore } from "@/store/recents";
 import { ScanMode } from "@/types";
@@ -71,7 +72,14 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
   const eliminarItem = useEliminarReposicionItemDirecto();
   const agregarVencimiento = useAgregarVencimientoItem();
   const { haptic } = useHaptics();
-  const registrarUso = useRecentsStore((s) => s.registrarUso);
+  const { tiendaActiva } = useAuth();
+  const tiendaId = tiendaActiva ?? SIN_TIENDA;
+  const registrarUsoStore = useRecentsStore((s) => s.registrarUso);
+  const registrarUso = useCallback(
+    (p: { varianteId: string; nombre: string; marca?: string; tamano?: string }) =>
+      registrarUsoStore(tiendaId, p),
+    [registrarUsoStore, tiendaId]
+  );
   const queryClient = useQueryClient();
 
   // Precargar el catálogo completo al abrir la cámara: si el código
@@ -81,12 +89,13 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
   // pero cubre el caso de abrir el escáner offline y recuperar señal recién
   // acá — React Query dedupe si ambos disparan casi simultáneo.
   useEffect(() => {
+    if (!tiendaActiva) return;
     queryClient.prefetchQuery({
-      queryKey: CATALOGO_COMPLETO_KEY,
-      queryFn: obtenerCatalogoCompleto,
+      queryKey: catalogoCompletoKey(tiendaActiva),
+      queryFn: () => obtenerCatalogoCompleto(tiendaActiva),
       staleTime: 30 * 60_000,
     });
-  }, []);
+  }, [queryClient, tiendaActiva]);
 
   const runEffect = useCallback(
     (effect: ScanFlowEffect) => {
@@ -199,7 +208,7 @@ export function ScanFlow({ scanMode, onClose, onRequestSearch }: ScanFlowProps) 
     // atrás: invalidar dispara un refetch inmediato en vez de esperar el
     // próximo sync. Más simple que mergear a mano (acá solo tenemos el
     // ProductoEscaneado reducido, no el ProductoCompleto completo).
-    queryClient.invalidateQueries({ queryKey: CATALOGO_COMPLETO_KEY });
+    queryClient.invalidateQueries({ queryKey: catalogoCompletoKey(tiendaId) });
     dispatch({ type: "CREATED", producto });
   };
 

--- a/src/components/search/ProductSearchSheet.tsx
+++ b/src/components/search/ProductSearchSheet.tsx
@@ -9,6 +9,8 @@ import {
   useEliminarReposicionItemDirecto,
 } from "@/hooks/useReposicion";
 import { useAgregarVencimientoItem } from "@/hooks/useVencimiento";
+import { useAuth } from "@/components/AuthProvider";
+import { SIN_TIENDA } from "@/lib/queryKeys";
 import { RecentEntry, useRecentsStore } from "@/store/recents";
 import { ProductoCompleto } from "@/services/catalogo";
 import { ScanMode } from "@/types";
@@ -66,7 +68,13 @@ export function ProductSearchSheet({ isOpen, onClose, mode }: ProductSearchSheet
   const actualizarCantidad = useActualizarCantidadReposicion();
   const eliminarItem = useEliminarReposicionItemDirecto();
   const agregarVencimiento = useAgregarVencimientoItem();
-  const registrarUso = useRecentsStore((s) => s.registrarUso);
+  const { tiendaActiva } = useAuth();
+  const registrarUsoStore = useRecentsStore((s) => s.registrarUso);
+  const registrarUso = useCallback(
+    (p: { varianteId: string; nombre: string; marca?: string; tamano?: string }) =>
+      registrarUsoStore(tiendaActiva ?? SIN_TIENDA, p),
+    [registrarUsoStore, tiendaActiva]
+  );
 
   const items = useMemo(() => resultados.map(aSearchItem), [resultados]);
 

--- a/src/hooks/__tests__/useReposicion.test.tsx
+++ b/src/hooks/__tests__/useReposicion.test.tsx
@@ -20,6 +20,18 @@ vi.mock("@/services/reposicion", () => ({
 // real de Supabase. Se mockea acá para no depender de env vars en este test.
 vi.mock("@/lib/supabase", () => ({ supabase: {} }));
 
+// Los hooks scopean las query keys por la tienda activa del AuthProvider.
+vi.mock("@/components/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: "user-test" },
+    cargando: false,
+    tiendaActiva: "tienda-test",
+    rol: "admin",
+  }),
+}));
+
+const ITEMS_KEY = ["tienda", "tienda-test", "reposicion", "items"];
+
 vi.mock("react-hot-toast", () => {
   let ultimoRenderProp: ((t: { id: string }) => React.ReactNode) | null = null;
   const toastFn = Object.assign(
@@ -74,7 +86,7 @@ describe("useDecrementarReposicion", () => {
     const { useDecrementarReposicion } = await import("@/hooks/useReposicion");
     const { eliminarItem } = await import("@/services/reposicion");
     const queryClient = new QueryClient();
-    queryClient.setQueryData(["reposicion", "items"], [ITEM]);
+    queryClient.setQueryData(ITEMS_KEY, [ITEM]);
 
     const { result } = renderHook(() => useDecrementarReposicion(), {
       wrapper: wrapper(queryClient),
@@ -83,7 +95,7 @@ describe("useDecrementarReposicion", () => {
     act(() => result.current(ITEM));
 
     // Optimista: desaparece del cache de inmediato
-    expect(queryClient.getQueryData(["reposicion", "items"])).toEqual([]);
+    expect(queryClient.getQueryData(ITEMS_KEY)).toEqual([]);
     expect(eliminarItem).not.toHaveBeenCalled();
 
     // Pasado el tiempo de "deshacer", se confirma el borrado real
@@ -102,20 +114,20 @@ describe("useDecrementarReposicion", () => {
       __getUltimoRenderProp: () => (t: { id: string }) => React.ReactNode;
     };
     const queryClient = new QueryClient();
-    queryClient.setQueryData(["reposicion", "items"], [ITEM]);
+    queryClient.setQueryData(ITEMS_KEY, [ITEM]);
 
     const { result } = renderHook(() => useDecrementarReposicion(), {
       wrapper: wrapper(queryClient),
     });
 
     act(() => result.current(ITEM));
-    expect(queryClient.getQueryData(["reposicion", "items"])).toEqual([]);
+    expect(queryClient.getQueryData(ITEMS_KEY)).toEqual([]);
 
     const renderProp = toastModule.__getUltimoRenderProp();
     render(<>{renderProp({ id: "toast-1" })}</>);
     act(() => screen.getByText("Deshacer").click());
 
-    expect(queryClient.getQueryData(["reposicion", "items"])).toEqual([ITEM]);
+    expect(queryClient.getQueryData(ITEMS_KEY)).toEqual([ITEM]);
 
     await act(async () => {
       vi.advanceTimersByTime(5000);

--- a/src/hooks/__tests__/useScanProduct.test.tsx
+++ b/src/hooks/__tests__/useScanProduct.test.tsx
@@ -1,12 +1,21 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { CATALOGO_COMPLETO_KEY } from "@/hooks/useCatalogoCompleto";
-import { eanQueryKey, useScanProduct } from "@/hooks/useScanProduct";
+import { catalogoCompletoKey, eanQueryKey } from "@/lib/queryKeys";
+import { useScanProduct } from "@/hooks/useScanProduct";
 import type { CatalogoCompleto, ProductoCompleto } from "@/services/catalogo";
 
 vi.mock("@/services/catalogo", () => ({
   buscarPorCodigoBarras: vi.fn(),
+}));
+
+vi.mock("@/components/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: "user-test" },
+    cargando: false,
+    tiendaActiva: "tienda-test",
+    rol: "admin",
+  }),
 }));
 
 const PRODUCTO: ProductoCompleto = {
@@ -50,7 +59,7 @@ describe("useScanProduct", () => {
     expect(res.status).toBe("found");
     if (res.status !== "found") throw new Error("unreachable");
     expect(res.producto.variante.id).toBe("var-1");
-    expect(queryClient.getQueryData(eanQueryKey("7790000000001"))).toBeTruthy();
+    expect(queryClient.getQueryData(eanQueryKey("tienda-test", "7790000000001"))).toBeTruthy();
 
     // Segundo escaneo del mismo EAN: sale del cache, sin otro round-trip
     await result.current.scanProduct("7790000000001");
@@ -88,7 +97,7 @@ describe("useScanProduct", () => {
       variantes: [PRODUCTO.variante],
       definiciones: { default: [], porCategoria: {} },
     };
-    queryClient.setQueryData(CATALOGO_COMPLETO_KEY, catalogo);
+    queryClient.setQueryData(catalogoCompletoKey("tienda-test"), catalogo);
     const { result } = setup(queryClient);
 
     const res = await result.current.scanProduct("7790000000001");
@@ -109,7 +118,7 @@ describe("useScanProduct", () => {
       variantes: [],
       definiciones: { default: [], porCategoria: {} },
     };
-    queryClient.setQueryData(CATALOGO_COMPLETO_KEY, catalogo);
+    queryClient.setQueryData(catalogoCompletoKey("tienda-test"), catalogo);
     const { result } = setup(queryClient);
 
     const res = await result.current.scanProduct("7790000000001");

--- a/src/hooks/useCatalogoCompleto.ts
+++ b/src/hooks/useCatalogoCompleto.ts
@@ -1,21 +1,23 @@
 "use client";
 
-import { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
+import { useAuth } from "@/components/AuthProvider";
+import { catalogoCompletoKey, SIN_TIENDA } from "@/lib/queryKeys";
 import { obtenerCatalogoCompleto } from "@/services/catalogo";
 import { useQuery } from "@tanstack/react-query";
 
-export { CATALOGO_COMPLETO_KEY } from "@/lib/queryKeys";
-
 /**
- * Todo el catálogo (bases + variantes + definiciones de atributos) en una
- * sola query, persistida en IndexedDB: es la fuente para lookup/búsqueda
- * offline (ver src/lib/catalogoLocal.ts). staleTime alto porque el
- * catálogo cambia con poca frecuencia comparado con las listas activas.
+ * Todo el catálogo (bases + variantes + definiciones de atributos) de la
+ * tienda activa en una sola query, persistida en IndexedDB: es la fuente
+ * para lookup/búsqueda offline (ver src/lib/catalogoLocal.ts). staleTime
+ * alto porque el catálogo cambia con poca frecuencia comparado con las
+ * listas activas.
  */
 export function useCatalogoCompleto() {
+  const { tiendaActiva } = useAuth();
   return useQuery({
-    queryKey: CATALOGO_COMPLETO_KEY,
-    queryFn: obtenerCatalogoCompleto,
+    queryKey: catalogoCompletoKey(tiendaActiva ?? SIN_TIENDA),
+    queryFn: () => obtenerCatalogoCompleto(tiendaActiva!),
+    enabled: !!tiendaActiva,
     staleTime: 30 * 60_000,
   });
 }

--- a/src/hooks/useNotificacionesVencimiento.ts
+++ b/src/hooks/useNotificacionesVencimiento.ts
@@ -11,6 +11,7 @@ import {
   seleccionarItemsANotificar,
   tienePermiso,
 } from "@/lib/notificacionesVencimiento";
+import { useAuth } from "@/components/AuthProvider";
 import { useNotificacionesStore } from "@/store/notificaciones";
 import { useEffect, useMemo } from "react";
 import { useProductosDeItems } from "./useProductosDeItems";
@@ -23,6 +24,7 @@ import { useVencimientoItems } from "./useVencimiento";
  * para el badge del tab.
  */
 export function useNotificacionesVencimiento() {
+  const { tiendaActiva } = useAuth();
   const { data: items = [] } = useVencimientoItems();
   const { data: productosPorVariante } = useProductosDeItems(
     items.map((i) => i.varianteId)
@@ -39,7 +41,7 @@ export function useNotificacionesVencimiento() {
   }, [urgentes.length]);
 
   useEffect(() => {
-    if (!habilitadas || !tienePermiso()) return;
+    if (!habilitadas || !tienePermiso() || !tiendaActiva) return;
     // Esperar los nombres del catálogo: notificar "Producto" no sirve de nada.
     if (urgentes.length > 0 && !productosPorVariante) return;
 
@@ -52,7 +54,7 @@ export function useNotificacionesVencimiento() {
       fechaVencimiento: item.fechaVencimiento,
     }));
 
-    const registro = leerNotificados();
+    const registro = leerNotificados(tiendaActiva);
     const nuevos = seleccionarItemsANotificar(notificables, registro);
     if (nuevos.length > 0) {
       void mostrarNotificacionVencimientos(nuevos);
@@ -64,8 +66,8 @@ export function useNotificacionesVencimiento() {
       },
       notificables
     );
-    guardarNotificados(actualizado);
-  }, [urgentes, productosPorVariante, habilitadas]);
+    guardarNotificados(tiendaActiva, actualizado);
+  }, [urgentes, productosPorVariante, habilitadas, tiendaActiva]);
 
   return { urgentesCount: urgentes.length };
 }

--- a/src/hooks/useReposicion.tsx
+++ b/src/hooks/useReposicion.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
 import { ejecutarMasivoOEncolar, ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
 import { crearTempId } from "@/lib/outbox/types";
 import {
-  REPOSICION_ESTADISTICAS_KEY as ESTADISTICAS_KEY,
-  REPOSICION_HISTORIAL_KEY as HISTORIAL_KEY,
-  REPOSICION_ITEMS_KEY as ITEMS_KEY,
+  reposicionEstadisticasKey,
+  reposicionHistorialKey,
+  reposicionItemsKey,
+  SIN_TIENDA,
 } from "@/lib/queryKeys";
 import * as reposicionService from "@/services/reposicion";
 import { EstadoReposicion, ItemReposicion } from "@/types";
@@ -14,8 +16,25 @@ import { QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/re
 import { useCallback } from "react";
 import toast from "react-hot-toast";
 
+/** Keys y tienda activa compartidas por todos los hooks del módulo. */
+function useReposicionScope() {
+  const { tiendaActiva } = useAuth();
+  const tiendaId = tiendaActiva ?? SIN_TIENDA;
+  return {
+    tiendaActiva,
+    ITEMS_KEY: reposicionItemsKey(tiendaId),
+    HISTORIAL_KEY: reposicionHistorialKey(tiendaId),
+    ESTADISTICAS_KEY: reposicionEstadisticasKey(tiendaId),
+  };
+}
+
 export function useReposicionItems() {
-  return useQuery({ queryKey: ITEMS_KEY, queryFn: reposicionService.listarItems });
+  const { tiendaActiva, ITEMS_KEY } = useReposicionScope();
+  return useQuery({
+    queryKey: ITEMS_KEY,
+    queryFn: () => reposicionService.listarItems(tiendaActiva!),
+    enabled: !!tiendaActiva,
+  });
 }
 
 /**
@@ -25,10 +44,11 @@ export function useReposicionItems() {
  */
 async function agregarOffline(
   queryClient: QueryClient,
+  itemsKey: readonly unknown[],
   varianteId: string,
   cantidad: number
 ): Promise<ItemReposicion> {
-  const actuales = queryClient.getQueryData<ItemReposicion[]>(ITEMS_KEY) ?? [];
+  const actuales = queryClient.getQueryData<ItemReposicion[]>(itemsKey) ?? [];
   const existente = actuales.find((i) => i.varianteId === varianteId);
   const ahora = new Date();
 
@@ -67,6 +87,7 @@ async function agregarOffline(
 
 export function useAgregarReposicionItem() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: async ({
@@ -83,7 +104,7 @@ export function useAgregarReposicionItem() {
           if (!isNetworkError(err)) throw err;
         }
       }
-      return agregarOffline(queryClient, varianteId, cantidad);
+      return agregarOffline(queryClient, ITEMS_KEY, varianteId, cantidad);
     },
     onSuccess: (item) => {
       queryClient.setQueryData<ItemReposicion[]>(ITEMS_KEY, (items) => {
@@ -99,6 +120,7 @@ export function useAgregarReposicionItem() {
 
 export function useActualizarCantidadReposicion() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: ({ id, cantidad }: { id: string; cantidad: number }) =>
@@ -124,6 +146,7 @@ export function useActualizarCantidadReposicion() {
 
 export function useCambiarEstadoReposicion() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: ({ id, estado }: { id: string; estado: EstadoReposicion }) =>
@@ -150,6 +173,7 @@ export function useCambiarEstadoReposicion() {
 /** Cambia el estado de varios items a la vez (acción masiva del modo selección). */
 export function useCambiarEstadoMasivo() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: ({ ids, estado }: { ids: string[]; estado: EstadoReposicion }) =>
@@ -176,6 +200,7 @@ export function useCambiarEstadoMasivo() {
 /** Elimina varios items a la vez (acción masiva del modo selección). */
 export function useEliminarItemsMasivo() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: (ids: string[]) =>
@@ -220,6 +245,7 @@ function useEliminarReposicionItem() {
  */
 export function useDecrementarReposicion() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   const actualizarCantidad = useActualizarCantidadReposicion();
   const eliminarItem = useEliminarReposicionItem();
 
@@ -260,13 +286,14 @@ export function useDecrementarReposicion() {
         { duration: 4000 }
       );
     },
-    [queryClient, actualizarCantidad, eliminarItem]
+    [queryClient, ITEMS_KEY, actualizarCantidad, eliminarItem]
   );
 }
 
 /** Borrado directo (sin pasar por el flujo de deshacer), para el ícono de basura. */
 export function useEliminarReposicionItemDirecto() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: (id: string) =>
@@ -292,6 +319,8 @@ export function useEliminarReposicionItemDirecto() {
 
 export function useGuardarListaReposicion() {
   const queryClient = useQueryClient();
+  const { tiendaActiva, ITEMS_KEY, HISTORIAL_KEY, ESTADISTICAS_KEY } =
+    useReposicionScope();
   return useMutation({
     networkMode: "always",
     mutationFn: async () => {
@@ -300,7 +329,10 @@ export function useGuardarListaReposicion() {
           "Necesitás conexión a internet para guardar la lista y cerrar el turno."
         );
       }
-      return reposicionService.guardarListaActual();
+      if (!tiendaActiva) {
+        throw new Error("No hay una tienda activa.");
+      }
+      return reposicionService.guardarListaActual(tiendaActiva);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ITEMS_KEY });
@@ -315,14 +347,17 @@ export function useHistorialReposicion(filtros?: {
   hasta?: Date;
   limite?: number;
 }) {
+  const { tiendaActiva, HISTORIAL_KEY } = useReposicionScope();
   return useQuery({
     queryKey: [...HISTORIAL_KEY, filtros],
-    queryFn: () => reposicionService.obtenerHistorial(filtros),
+    queryFn: () => reposicionService.obtenerHistorial(tiendaActiva!, filtros),
+    enabled: !!tiendaActiva,
   });
 }
 
 export function useEliminarListaHistorial() {
   const queryClient = useQueryClient();
+  const { HISTORIAL_KEY } = useReposicionScope();
   return useMutation({
     mutationFn: (id: string) => reposicionService.eliminarListaHistorial(id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: HISTORIAL_KEY }),
@@ -330,8 +365,10 @@ export function useEliminarListaHistorial() {
 }
 
 export function useEstadisticasReposicion(periodo: "semana" | "mes" | "año") {
+  const { tiendaActiva, ESTADISTICAS_KEY } = useReposicionScope();
   return useQuery({
     queryKey: [...ESTADISTICAS_KEY, periodo],
-    queryFn: () => reposicionService.obtenerEstadisticas(periodo),
+    queryFn: () => reposicionService.obtenerEstadisticas(tiendaActiva!, periodo),
+    enabled: !!tiendaActiva,
   });
 }

--- a/src/hooks/useScanProduct.ts
+++ b/src/hooks/useScanProduct.ts
@@ -1,7 +1,8 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import { buscarPorCodigoBarrasLocal } from "@/lib/catalogoLocal";
-import { CATALOGO_COMPLETO_KEY, eanQueryKey } from "@/lib/queryKeys";
+import { catalogoCompletoKey, eanQueryKey, SIN_TIENDA } from "@/lib/queryKeys";
 import { buscarPorCodigoBarras, CatalogoCompleto, ProductoCompleto } from "@/services/catalogo";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -41,31 +42,34 @@ export type ScanLookupResult =
  * sesión actual (encadenando varios ítems) no pague otro round-trip. */
 const EAN_STALE_TIME = 10 * 60_000;
 
-export { eanQueryKey } from "@/lib/queryKeys";
-
 export function useScanProduct() {
   const queryClient = useQueryClient();
+  const { tiendaActiva } = useAuth();
+  const tiendaId = tiendaActiva ?? SIN_TIENDA;
 
   const scanProduct = useCallback(
     async (barcode: string): Promise<ScanLookupResult> => {
       // Cachea por EAN: sólo "no encontrado" no se cachea, para no
       // bloquear el alta manual del mismo código en la misma sesión.
-      const cached = queryClient.getQueryData<ProductoEscaneado>(eanQueryKey(barcode));
+      const cached = queryClient.getQueryData<ProductoEscaneado>(
+        eanQueryKey(tiendaId, barcode)
+      );
       if (cached) return { status: "found", producto: cached };
+      if (!tiendaActiva) return { status: "error" };
 
       try {
         // Directo a Supabase: antes pasaba por /api/productos/buscar
         // (función de Vercel), un hop extra de latencia en el camino
         // crítico del escaneo que además convertía cualquier caída de
         // red en un falso "no encontrado".
-        const resultado = await buscarPorCodigoBarras(barcode);
+        const resultado = await buscarPorCodigoBarras(tiendaActiva, barcode);
         if (!resultado) return { status: "not_found" };
 
         const producto = aProductoEscaneado(resultado);
-        queryClient.setQueryData(eanQueryKey(barcode), producto, {
+        queryClient.setQueryData(eanQueryKey(tiendaId, barcode), producto, {
           updatedAt: Date.now(),
         });
-        queryClient.setQueryDefaults(eanQueryKey(barcode), {
+        queryClient.setQueryDefaults(eanQueryKey(tiendaId, barcode), {
           staleTime: EAN_STALE_TIME,
         });
         return { status: "found", producto };
@@ -76,15 +80,17 @@ export function useScanProduct() {
         // online (por eso este fallback vive en el catch, no reemplaza la
         // llamada de red) pero evita bloquear un escaneo offline de un
         // producto que sí está en el catálogo cacheado.
-        const catalogo = queryClient.getQueryData<CatalogoCompleto>(CATALOGO_COMPLETO_KEY);
+        const catalogo = queryClient.getQueryData<CatalogoCompleto>(
+          catalogoCompletoKey(tiendaId)
+        );
         if (catalogo) {
           const resultadoLocal = buscarPorCodigoBarrasLocal(catalogo, barcode);
           if (resultadoLocal) {
             const producto = aProductoEscaneado(resultadoLocal);
-            queryClient.setQueryData(eanQueryKey(barcode), producto, {
+            queryClient.setQueryData(eanQueryKey(tiendaId, barcode), producto, {
               updatedAt: Date.now(),
             });
-            queryClient.setQueryDefaults(eanQueryKey(barcode), {
+            queryClient.setQueryDefaults(eanQueryKey(tiendaId, barcode), {
               staleTime: EAN_STALE_TIME,
             });
             return { status: "found", producto };
@@ -93,16 +99,16 @@ export function useScanProduct() {
         return { status: "error" };
       }
     },
-    [queryClient]
+    [queryClient, tiendaActiva, tiendaId]
   );
 
   /** Sembrar el cache tras un alta manual, para que el próximo escaneo del
    * mismo EAN en la sesión no dispare otra consulta. */
   const seedProducto = useCallback(
     (ean: string, producto: ProductoEscaneado) => {
-      queryClient.setQueryData(eanQueryKey(ean), producto);
+      queryClient.setQueryData(eanQueryKey(tiendaId, ean), producto);
     },
-    [queryClient]
+    [queryClient, tiendaId]
   );
 
   return { scanProduct, seedProducto };

--- a/src/hooks/useVencimiento.tsx
+++ b/src/hooks/useVencimiento.tsx
@@ -1,22 +1,38 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import { enqueueOperation, isNetworkError, isOnline } from "@/lib/outbox/outbox";
 import { ejecutarMasivoOEncolar, ejecutarOEncolar } from "@/lib/outbox/mutationHelpers";
 import { crearTempId } from "@/lib/outbox/types";
 import {
-  VENCIMIENTO_ESTADISTICAS_KEY as ESTADISTICAS_KEY,
-  VENCIMIENTO_HISTORIAL_KEY as HISTORIAL_KEY,
-  VENCIMIENTO_ITEMS_KEY as ITEMS_KEY,
+  SIN_TIENDA,
+  vencimientoEstadisticasKey,
+  vencimientoHistorialKey,
+  vencimientoItemsKey,
 } from "@/lib/queryKeys";
 import { calcularNivelAlerta, toDateInputValue } from "@/lib/utils";
 import * as vencimientoService from "@/services/vencimiento";
 import { ItemVencimientoConAlerta } from "@/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+/** Keys y tienda activa compartidas por todos los hooks del módulo. */
+function useVencimientoScope() {
+  const { tiendaActiva } = useAuth();
+  const tiendaId = tiendaActiva ?? SIN_TIENDA;
+  return {
+    tiendaActiva,
+    ITEMS_KEY: vencimientoItemsKey(tiendaId),
+    HISTORIAL_KEY: vencimientoHistorialKey(tiendaId),
+    ESTADISTICAS_KEY: vencimientoEstadisticasKey(tiendaId),
+  };
+}
+
 export function useVencimientoItems() {
+  const { tiendaActiva, ITEMS_KEY } = useVencimientoScope();
   return useQuery({
     queryKey: ITEMS_KEY,
-    queryFn: vencimientoService.listarItems,
+    queryFn: () => vencimientoService.listarItems(tiendaActiva!),
+    enabled: !!tiendaActiva,
     // Re-deriva el nivel de alerta al leer: los datos pueden venir del
     // cache persistido (arranque offline) o de una app abierta toda la
     // noche, con un alertaNivel calculado días atrás.
@@ -30,6 +46,7 @@ export function useVencimientoItems() {
 
 export function useAgregarVencimientoItem() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useVencimientoScope();
   return useMutation({
     networkMode: "always",
     mutationFn: async ({
@@ -91,6 +108,7 @@ export function useAgregarVencimientoItem() {
 
 export function useActualizarFechaVencimiento() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useVencimientoScope();
   return useMutation({
     networkMode: "always",
     mutationFn: ({ id, fechaVencimiento }: { id: string; fechaVencimiento: Date }) =>
@@ -124,6 +142,7 @@ export function useActualizarFechaVencimiento() {
 
 export function useActualizarCantidadVencimiento() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useVencimientoScope();
   return useMutation({
     networkMode: "always",
     mutationFn: ({ id, cantidad }: { id: string; cantidad: number }) =>
@@ -149,6 +168,7 @@ export function useActualizarCantidadVencimiento() {
 
 export function useEliminarVencimientoItem() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY } = useVencimientoScope();
   return useMutation({
     networkMode: "always",
     mutationFn: (id: string) =>
@@ -175,6 +195,7 @@ export function useEliminarVencimientoItem() {
 /** Retira el item de la góndola: lo archiva en el historial y lo saca de la lista activa. */
 export function useRetirarVencimientoItem() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY, HISTORIAL_KEY, ESTADISTICAS_KEY } = useVencimientoScope();
   return useMutation({
     networkMode: "always",
     mutationFn: (id: string) =>
@@ -206,6 +227,7 @@ export function useRetirarVencimientoItem() {
 /** Retira varios items a la vez (acción masiva del modo selección). */
 export function useRetirarItemsMasivo() {
   const queryClient = useQueryClient();
+  const { ITEMS_KEY, HISTORIAL_KEY, ESTADISTICAS_KEY } = useVencimientoScope();
   return useMutation({
     networkMode: "always",
     mutationFn: (ids: string[]) =>
@@ -239,15 +261,19 @@ export function useHistorialVencimiento(filtros?: {
   hasta?: Date;
   limite?: number;
 }) {
+  const { tiendaActiva, HISTORIAL_KEY } = useVencimientoScope();
   return useQuery({
     queryKey: [...HISTORIAL_KEY, filtros],
-    queryFn: () => vencimientoService.obtenerHistorial(filtros),
+    queryFn: () => vencimientoService.obtenerHistorial(tiendaActiva!, filtros),
+    enabled: !!tiendaActiva,
   });
 }
 
 export function useEstadisticasVencimiento(periodo: "semana" | "mes" | "año") {
+  const { tiendaActiva, ESTADISTICAS_KEY } = useVencimientoScope();
   return useQuery({
     queryKey: [...ESTADISTICAS_KEY, periodo],
-    queryFn: () => vencimientoService.obtenerEstadisticas(periodo),
+    queryFn: () => vencimientoService.obtenerEstadisticas(tiendaActiva!, periodo),
+    enabled: !!tiendaActiva,
   });
 }

--- a/src/lib/__tests__/queryPersister.test.ts
+++ b/src/lib/__tests__/queryPersister.test.ts
@@ -38,19 +38,23 @@ describe("deserializarConFechas", () => {
 });
 
 describe("esQueryPersistible", () => {
-  it("persiste las listas activas, el catálogo completo y los EAN resueltos", () => {
-    expect(esQueryPersistible(["reposicion", "items"])).toBe(true);
-    expect(esQueryPersistible(["vencimiento", "items"])).toBe(true);
-    expect(esQueryPersistible(["catalogo", "completo"])).toBe(true);
-    expect(esQueryPersistible(["producto", "ean", "779..."])).toBe(true);
+  const T = ["tienda", "tienda-test"] as const;
+
+  it("persiste las listas activas, el catálogo completo y los EAN resueltos (con prefijo de tienda)", () => {
+    expect(esQueryPersistible([...T, "reposicion", "items"])).toBe(true);
+    expect(esQueryPersistible([...T, "vencimiento", "items"])).toBe(true);
+    expect(esQueryPersistible([...T, "catalogo", "completo"])).toBe(true);
+    expect(esQueryPersistible([...T, "producto", "ean", "779..."])).toBe(true);
   });
 
   it("no persiste historial, estadísticas ni otras queries", () => {
-    expect(esQueryPersistible(["reposicion", "historial"])).toBe(false);
-    expect(esQueryPersistible(["vencimiento", "estadisticas", "mes"])).toBe(false);
+    expect(esQueryPersistible([...T, "reposicion", "historial"])).toBe(false);
+    expect(esQueryPersistible([...T, "vencimiento", "estadisticas", "mes"])).toBe(false);
     expect(esQueryPersistible(["marcas-categorias"])).toBe(false);
-    // Reemplazada por ["catalogo","completo"]: useProductosDeItems ya no
-    // dispara un useQuery propio, deriva del catálogo completo vía useMemo.
-    expect(esQueryPersistible(["catalogo", "por-variante-ids", ["v1"]])).toBe(false);
+  });
+
+  it("no persiste keys sin prefijo de tienda (shape pre-Fase 2)", () => {
+    expect(esQueryPersistible(["reposicion", "items"])).toBe(false);
+    expect(esQueryPersistible(["catalogo", "completo"])).toBe(false);
   });
 });

--- a/src/lib/limpiarEstadoLocal.ts
+++ b/src/lib/limpiarEstadoLocal.ts
@@ -5,6 +5,7 @@ import {
 import { clearQueue } from "@/lib/outbox/outbox";
 import { limpiarCachePersistido } from "@/lib/queryPersister";
 import { useRecentsStore } from "@/store/recents";
+import { useSesionStore } from "@/store/sesion";
 
 /**
  * Limpieza local completa al cerrar sesión (docs/SPECMULTIUSER.md §3.2).
@@ -22,6 +23,10 @@ export async function limpiarEstadoLocal(): Promise<void> {
   // Recientes/frecuentes (nombres de productos de la tienda).
   useRecentsStore.setState({ entries: {} });
   useRecentsStore.persist.clearStorage();
+
+  // Tienda activa y rol persistidos (identidad del próximo usuario).
+  useSesionStore.getState().setTienda(null, null);
+  useSesionStore.persist.clearStorage();
 
   // Registro de vencimientos ya notificados + badge del ícono.
   limpiarNotificados();

--- a/src/lib/notificacionesVencimiento.ts
+++ b/src/lib/notificacionesVencimiento.ts
@@ -80,29 +80,43 @@ export function construirMensaje(items: ItemNotificable[]): {
   };
 }
 
-export function leerNotificados(): RegistroNotificados {
+// Registro por tienda (Fase 2): al cambiar de tienda, la poda del registro
+// de una no debe pisar el de la otra.
+function claveDeTienda(tiendaId: string): string {
+  return `${STORAGE_KEY}:${tiendaId}`;
+}
+
+export function leerNotificados(tiendaId: string): RegistroNotificados {
   if (typeof window === "undefined") return {};
   try {
-    return JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}");
+    return JSON.parse(window.localStorage.getItem(claveDeTienda(tiendaId)) ?? "{}");
   } catch {
     return {};
   }
 }
 
-export function guardarNotificados(registro: RegistroNotificados): void {
+export function guardarNotificados(
+  tiendaId: string,
+  registro: RegistroNotificados
+): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(registro));
+    window.localStorage.setItem(claveDeTienda(tiendaId), JSON.stringify(registro));
   } catch {
     // Almacenamiento lleno o bloqueado: se reintenta en el próximo ciclo.
   }
 }
 
-/** Borra el registro de notificados (logout, spec §3.2). */
+/** Borra el registro de notificados de TODAS las tiendas (logout, spec §3.2). */
 export function limpiarNotificados(): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(STORAGE_KEY);
+    const aBorrar: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const clave = window.localStorage.key(i);
+      if (clave?.startsWith(STORAGE_KEY)) aBorrar.push(clave);
+    }
+    aBorrar.forEach((clave) => window.localStorage.removeItem(clave));
   } catch {
     // sin acceso a storage: nada que borrar
   }

--- a/src/lib/outbox/outbox.ts
+++ b/src/lib/outbox/outbox.ts
@@ -5,14 +5,26 @@ import { outboxStore } from "./db";
 import { ejecutarOperacion } from "./executors";
 import { OutboxOperation, OutboxOperationType, PayloadOf } from "./types";
 
-const QUEUE_KEY = "queue";
+// Cola por usuario (spec §4.3): en un dispositivo compartido, el trabajo
+// offline de un usuario nunca se ejecuta con la sesión de otro. AuthProvider
+// setea el usuario actual; sin usuario (tests, arranque) se usa la clave
+// legacy "queue".
+let usuarioActual: string | null = null;
+
+export function setUsuarioOutbox(userId: string | null): void {
+  usuarioActual = userId;
+}
+
+function queueKey(): string {
+  return usuarioActual ? `queue:${usuarioActual}` : "queue";
+}
 
 async function readQueue(): Promise<OutboxOperation[]> {
-  return (await get<OutboxOperation[]>(QUEUE_KEY, outboxStore)) ?? [];
+  return (await get<OutboxOperation[]>(queueKey(), outboxStore)) ?? [];
 }
 
 async function writeQueue(queue: OutboxOperation[]): Promise<void> {
-  await set(QUEUE_KEY, queue, outboxStore);
+  await set(queueKey(), queue, outboxStore);
   useOutboxStore.getState().setPendingCount(queue.length);
 }
 
@@ -37,7 +49,7 @@ export async function countPending(): Promise<number> {
 
 /** Vacía la cola sin ejecutar nada (logout vía limpiarEstadoLocal, tests). */
 export async function clearQueue(): Promise<void> {
-  await del(QUEUE_KEY, outboxStore);
+  await del(queueKey(), outboxStore);
   useOutboxStore.getState().setPendingCount(0);
 }
 
@@ -99,6 +111,16 @@ export async function processQueue(): Promise<void> {
         const resultado = await ejecutarOperacion(op, resolveId);
         if (resultado?.tempId && resultado.realId) {
           idMap.set(resultado.tempId, resultado.realId);
+          // Persistir el remap también EN la cola: si la corrida se corta
+          // acá (red, 401) y se reanuda en otra sesión, las operaciones
+          // dependientes ya apuntan al id real — antes el idMap era solo
+          // por-corrida y esas operaciones quedaban con un "offline:" sin
+          // resolver que terminaba descartado.
+          for (const pendiente of resto) {
+            if ("id" in pendiente.payload && pendiente.payload.id === resultado.tempId) {
+              pendiente.payload.id = resultado.realId;
+            }
+          }
         }
         await writeQueue(resto);
       } catch (err) {

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -2,21 +2,37 @@
  * Definiciones centralizadas de las query keys de React Query.
  *
  * Única fuente de verdad para las keys que comparten hooks, providers y el
- * persister (ver docs/SPECMULTIUSER.md §4.1): en la Fase 2 del proyecto
- * multi-tienda todas ganan el prefijo `["tienda", tiendaId, ...]` tocando
- * solo este módulo (las constantes pasan a factories que reciben tiendaId).
+ * persister. Desde la Fase 2 multi-tienda (docs/SPECMULTIUSER.md §4.1)
+ * todas llevan el prefijo `["tienda", tiendaId, ...]`: los datos de dos
+ * tiendas nunca comparten entrada de cache.
  */
 
-export const REPOSICION_ITEMS_KEY = ["reposicion", "items"] as const;
-export const REPOSICION_HISTORIAL_KEY = ["reposicion", "historial"] as const;
-export const REPOSICION_ESTADISTICAS_KEY = ["reposicion", "estadisticas"] as const;
+export const SIN_TIENDA = "sin-tienda";
 
-export const VENCIMIENTO_ITEMS_KEY = ["vencimiento", "items"] as const;
-export const VENCIMIENTO_HISTORIAL_KEY = ["vencimiento", "historial"] as const;
-export const VENCIMIENTO_ESTADISTICAS_KEY = ["vencimiento", "estadisticas"] as const;
+export function reposicionItemsKey(tiendaId: string) {
+  return ["tienda", tiendaId, "reposicion", "items"] as const;
+}
+export function reposicionHistorialKey(tiendaId: string) {
+  return ["tienda", tiendaId, "reposicion", "historial"] as const;
+}
+export function reposicionEstadisticasKey(tiendaId: string) {
+  return ["tienda", tiendaId, "reposicion", "estadisticas"] as const;
+}
 
-export const CATALOGO_COMPLETO_KEY = ["catalogo", "completo"] as const;
+export function vencimientoItemsKey(tiendaId: string) {
+  return ["tienda", tiendaId, "vencimiento", "items"] as const;
+}
+export function vencimientoHistorialKey(tiendaId: string) {
+  return ["tienda", tiendaId, "vencimiento", "historial"] as const;
+}
+export function vencimientoEstadisticasKey(tiendaId: string) {
+  return ["tienda", tiendaId, "vencimiento", "estadisticas"] as const;
+}
 
-export function eanQueryKey(ean: string) {
-  return ["producto", "ean", ean] as const;
+export function catalogoCompletoKey(tiendaId: string) {
+  return ["tienda", tiendaId, "catalogo", "completo"] as const;
+}
+
+export function eanQueryKey(tiendaId: string, ean: string) {
+  return ["tienda", tiendaId, "producto", "ean", ean] as const;
 }

--- a/src/lib/queryPersister.ts
+++ b/src/lib/queryPersister.ts
@@ -48,13 +48,15 @@ export function deserializarConFechas(cached: string) {
  * sin señal: las dos listas activas, el catálogo completo (bases +
  * variantes + definiciones, ver useCatalogoCompleto) y los EAN ya
  * resueltos. Historial y estadísticas se consultan con calma y online.
+ * Las keys llevan prefijo de tienda desde la Fase 2 (ver queryKeys.ts).
  */
 export function esQueryPersistible(queryKey: readonly unknown[]): boolean {
+  if (queryKey[0] !== "tienda" || typeof queryKey[1] !== "string") return false;
   return (
-    (queryKey[0] === "reposicion" && queryKey[1] === "items") ||
-    (queryKey[0] === "vencimiento" && queryKey[1] === "items") ||
-    (queryKey[0] === "catalogo" && queryKey[1] === "completo") ||
-    (queryKey[0] === "producto" && queryKey[1] === "ean")
+    (queryKey[2] === "reposicion" && queryKey[3] === "items") ||
+    (queryKey[2] === "vencimiento" && queryKey[3] === "items") ||
+    (queryKey[2] === "catalogo" && queryKey[3] === "completo") ||
+    (queryKey[2] === "producto" && queryKey[3] === "ean")
   );
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -141,9 +141,13 @@ export default async function proxy(request: NextRequest) {
     return addSecurityHeaders(await gateDeSesion(request));
   }
 
-  // Obtener IP del cliente
+  // Clave del rate limit: usuario si hay cookie de sesión, IP como fallback.
+  // El sub se decodifica SIN verificar firma — spoofearlo solo cambia tu
+  // bucket de rate limit; la autorización real la hace el route handler con
+  // su cliente por-request.
   const ip = getClientIp(request);
-  const identifier = `ip:${ip}`;
+  const sub = extraerSubDeSesion(request);
+  const identifier = sub ? `user:${sub}` : `ip:${ip}`;
 
   // En desarrollo, permitir todo
   if (process.env.NODE_ENV === "development" || !redis) {
@@ -279,6 +283,36 @@ export default async function proxy(request: NextRequest) {
     console.error("❌ Error en rate limiting:", error);
     // En caso de error, permitir la request pero loggear
     return addSecurityHeaders(NextResponse.next());
+  }
+}
+
+function decodificarBase64Url(valor: string): string {
+  return atob(valor.replace(/-/g, "+").replace(/_/g, "/"));
+}
+
+/** sub del JWT de la cookie de Supabase, sin verificar firma (solo rate limit). */
+function extraerSubDeSesion(request: NextRequest): string | null {
+  try {
+    const chunks = request.cookies
+      .getAll()
+      .filter((c) => /^sb-.*-auth-token(\.\d+)?$/.test(c.name))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+      .map((c) => c.value);
+    if (chunks.length === 0) return null;
+
+    let crudo = chunks.join("");
+    if (crudo.startsWith("base64-")) {
+      crudo = decodificarBase64Url(crudo.slice("base64-".length));
+    }
+    const sesion = JSON.parse(crudo) as { access_token?: string };
+    if (!sesion.access_token) return null;
+
+    const payload = JSON.parse(
+      decodificarBase64Url(sesion.access_token.split(".")[1])
+    ) as { sub?: string };
+    return payload.sub ?? null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/services/__tests__/catalogo.test.ts
+++ b/src/services/__tests__/catalogo.test.ts
@@ -36,7 +36,7 @@ describe("buscarPorCodigoBarras", () => {
     const { buscarPorCodigoBarras } = await import("@/services/catalogo");
     fromMock.mockImplementation(mockSupabaseFrom({ data: null }));
 
-    const resultado = await buscarPorCodigoBarras("0000000000000");
+    const resultado = await buscarPorCodigoBarras("tienda-test", "0000000000000");
     expect(resultado).toBeNull();
   });
 
@@ -46,7 +46,7 @@ describe("buscarPorCodigoBarras", () => {
       mockSupabaseFrom({ data: { ...varianteRow, producto_bases: baseRow } })
     );
 
-    const resultado = await buscarPorCodigoBarras(varianteRow.codigo_barras);
+    const resultado = await buscarPorCodigoBarras("tienda-test", varianteRow.codigo_barras);
     expect(resultado).not.toBeNull();
     expect(resultado!.variante.codigoBarras).toBe("7791234567890");
     expect(resultado!.base.nombre).toBe("Leche");
@@ -60,7 +60,7 @@ describe("buscarPorCodigoBarras", () => {
       mockSupabaseFrom({ error: new Error("conexión perdida") })
     );
 
-    await expect(buscarPorCodigoBarras("123")).rejects.toThrow("conexión perdida");
+    await expect(buscarPorCodigoBarras("tienda-test", "123")).rejects.toThrow("conexión perdida");
   });
 });
 
@@ -79,7 +79,7 @@ describe("crearProductoManual", () => {
       mockSupabaseFrom({ data: { id: "ya-existe" } }, { data: null })
     );
 
-    await expect(crearProductoManual(dto)).rejects.toThrow("ya existe en el catálogo");
+    await expect(crearProductoManual("tienda-test", dto)).rejects.toThrow("ya existe en el catálogo");
   });
 
   it("reutiliza el producto base si ya existe uno con el mismo nombre+marca", async () => {
@@ -101,7 +101,7 @@ describe("crearProductoManual", () => {
       )
     );
 
-    const resultado = await crearProductoManual(dto);
+    const resultado = await crearProductoManual("tienda-test", dto);
     expect(resultado.base.id).toBe("base-1");
     expect(resultado.variante.id).toBe("variante-nueva");
     expect(fromMock).toHaveBeenCalledTimes(3);
@@ -118,7 +118,12 @@ describe("crearProductoManual", () => {
     fromMock.mockImplementation((tabla: string) => {
       if (tabla === "producto_variantes") {
         return {
-          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+          // .eq(tienda_id).eq(codigo_barras).maybeSingle()
+          select: () => ({
+            eq: () => ({
+              eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }),
+            }),
+          }),
           insert: (payload: Record<string, unknown>) => {
             payloadInsertado = payload;
             return {
@@ -139,13 +144,17 @@ describe("crearProductoManual", () => {
       }
       return {
         select: () => ({
-          // El lookup de base usa ilike (igualdad case-insensitive, ver 0010)
-          ilike: () => ({ ilike: () => ({ maybeSingle: async () => ({ data: baseRow, error: null }) }) }),
+          // El lookup de base usa .eq(tienda) + ilike (case-insensitive, ver 0010)
+          eq: () => ({
+            ilike: () => ({
+              ilike: () => ({ maybeSingle: async () => ({ data: baseRow, error: null }) }),
+            }),
+          }),
         }),
       };
     });
 
-    await crearProductoManual(dtoSucio);
+    await crearProductoManual("tienda-test", dtoSucio);
 
     expect(payloadInsertado).not.toHaveProperty("nombre_completo");
     expect(payloadInsertado?.atributos).toEqual({ tipo: "Con Palo", tamano: "1kg" });
@@ -172,7 +181,7 @@ describe("crearProductoManual", () => {
       )
     );
 
-    const resultado = await crearProductoManual(dto);
+    const resultado = await crearProductoManual("tienda-test", dto);
     expect(resultado.base.id).toBe("base-nueva");
     expect(fromMock).toHaveBeenCalledTimes(4);
   });
@@ -229,7 +238,7 @@ describe("obtenerDefinicionesAtributos", () => {
       })
     );
 
-    const defs = await obtenerDefinicionesAtributos();
+    const defs = await obtenerDefinicionesAtributos("tienda-test");
 
     expect(defs.default.map((d) => d.clave)).toEqual(["tipo", "sabor"]);
     expect(defs.porCategoria["Ferretería"]).toEqual([
@@ -254,7 +263,7 @@ describe("obtenerMarcasYCategorias", () => {
       })
     );
 
-    const { marcas, categorias } = await obtenerMarcasYCategorias();
+    const { marcas, categorias } = await obtenerMarcasYCategorias("tienda-test");
     expect(marcas).toEqual(["Arcor", "Nestlé"]);
     expect(categorias).toEqual(["Golosinas", "Lácteos"]);
   });
@@ -275,7 +284,7 @@ describe("obtenerCatalogoCompleto", () => {
       )
     );
 
-    const catalogo = await obtenerCatalogoCompleto();
+    const catalogo = await obtenerCatalogoCompleto("tienda-test");
 
     expect(catalogo.bases).toEqual([expect.objectContaining({ id: "base-1", nombre: "Leche" })]);
     expect(catalogo.variantes).toEqual([
@@ -295,7 +304,7 @@ describe("obtenerCatalogoCompleto", () => {
       )
     );
 
-    await expect(obtenerCatalogoCompleto()).rejects.toThrow("bases caídas");
+    await expect(obtenerCatalogoCompleto("tienda-test")).rejects.toThrow("bases caídas");
   });
 
   it("propaga el error si falla la consulta de variantes", async () => {
@@ -308,14 +317,14 @@ describe("obtenerCatalogoCompleto", () => {
       )
     );
 
-    await expect(obtenerCatalogoCompleto()).rejects.toThrow("variantes caídas");
+    await expect(obtenerCatalogoCompleto("tienda-test")).rejects.toThrow("variantes caídas");
   });
 });
 
 describe("buscarProductos", () => {
   it("no consulta la base si el término sanitizado queda muy corto", async () => {
     const { buscarProductos } = await import("@/services/catalogo");
-    const resultado = await buscarProductos(" ,%) (");
+    const resultado = await buscarProductos("tienda-test", " ,%) (");
 
     expect(resultado).toEqual([]);
     expect(fromMock).not.toHaveBeenCalled();
@@ -326,7 +335,7 @@ describe("buscarProductos", () => {
     // Sin sanitizar tiene 4 caracteres (pasaría el mínimo); sanitizado
     // ("a") queda en 1 y debe cortar antes de tocar la base — así se prueba
     // que la sanitización corre ANTES del chequeo de longitud mínima.
-    const resultado = await buscarProductos(",,a,");
+    const resultado = await buscarProductos("tienda-test", ",,a,");
 
     expect(resultado).toEqual([]);
     expect(fromMock).not.toHaveBeenCalled();
@@ -336,7 +345,7 @@ describe("buscarProductos", () => {
 describe("buscarVariantes", () => {
   it("no consulta la base si el término sanitizado queda muy corto", async () => {
     const { buscarVariantes } = await import("@/services/catalogo");
-    const resultado = await buscarVariantes("a,");
+    const resultado = await buscarVariantes("tienda-test", "a,");
 
     expect(resultado).toEqual([]);
     expect(fromMock).not.toHaveBeenCalled();
@@ -364,7 +373,7 @@ describe("buscarVariantes", () => {
       )
     );
 
-    const resultado = await buscarVariantes("leche");
+    const resultado = await buscarVariantes("tienda-test", "leche");
 
     expect(resultado).toHaveLength(2);
     expect(resultado.map((p) => p.variante.id).sort()).toEqual([

--- a/src/services/__tests__/parseoProducto.test.ts
+++ b/src/services/__tests__/parseoProducto.test.ts
@@ -131,7 +131,7 @@ describe("parsearProducto", () => {
     const { parsearProducto, IANoConfiguradaError } = await import(
       "@/services/parseoProducto"
     );
-    await expect(parsearProducto("Leche Milex 2200g")).rejects.toThrow(
+    await expect(parsearProducto("Leche Milex 2200g", "tienda-test")).rejects.toThrow(
       IANoConfiguradaError
     );
     expect(createMock).not.toHaveBeenCalled();
@@ -150,7 +150,7 @@ describe("parsearProducto", () => {
     );
     const { parsearProducto } = await import("@/services/parseoProducto");
 
-    const parsed = await parsearProducto("leche milex 2200 gramos");
+    const parsed = await parsearProducto("leche milex 2200 gramos", "tienda-test");
 
     expect(parsed.productoBase).toEqual({
       nombre: "Leche Milex",
@@ -182,7 +182,7 @@ describe("parsearProducto", () => {
     const { parsearProducto, ParseoInvalidoError } = await import(
       "@/services/parseoProducto"
     );
-    await expect(parsearProducto("algo")).rejects.toThrow(ParseoInvalidoError);
+    await expect(parsearProducto("algo", "tienda-test")).rejects.toThrow(ParseoInvalidoError);
   });
 
   it("usa Gemini directamente cuando solo hay GEMINI_API_KEY", async () => {
@@ -199,7 +199,7 @@ describe("parsearProducto", () => {
     );
     const { parsearProducto } = await import("@/services/parseoProducto");
 
-    const parsed = await parsearProducto("leche milex 2200g");
+    const parsed = await parsearProducto("leche milex 2200g", "tienda-test");
 
     expect(createMock).not.toHaveBeenCalled();
     expect(parsed.productoBase.nombre).toBe("Leche Milex");
@@ -232,7 +232,7 @@ describe("parsearProducto", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { parsearProducto } = await import("@/services/parseoProducto");
 
-    const parsed = await parsearProducto("compota gerber");
+    const parsed = await parsearProducto("compota gerber", "tienda-test");
 
     expect(createMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -249,7 +249,7 @@ describe("parsearProducto", () => {
     createMock.mockRejectedValue(new Error("rate limited"));
     const { parsearProducto } = await import("@/services/parseoProducto");
 
-    await expect(parsearProducto("algo")).rejects.toThrow("rate limited");
+    await expect(parsearProducto("algo", "tienda-test")).rejects.toThrow("rate limited");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -272,6 +272,6 @@ describe("parsearProducto", () => {
     const { parsearProducto, ParseoInvalidoError } = await import(
       "@/services/parseoProducto"
     );
-    await expect(parsearProducto("algo")).rejects.toThrow(ParseoInvalidoError);
+    await expect(parsearProducto("algo", "tienda-test")).rejects.toThrow(ParseoInvalidoError);
   });
 });

--- a/src/services/__tests__/reposicion.test.ts
+++ b/src/services/__tests__/reposicion.test.ts
@@ -33,7 +33,7 @@ describe("listarItems", () => {
     const { listarItems } = await import("@/services/reposicion");
     fromMock.mockImplementation(mockSupabaseFrom({ data: [itemRow()] }));
 
-    const items = await listarItems();
+    const items = await listarItems("tienda-test");
     expect(items).toHaveLength(1);
     expect(items[0]).toMatchObject({ id: "item-1", varianteId: "variante-1", cantidad: 3, estado: "pendiente" });
     expect(items[0].agregadoAt).toBeInstanceOf(Date);
@@ -121,8 +121,10 @@ describe("guardarListaActual", () => {
     const { guardarListaActual } = await import("@/services/reposicion");
     rpcMock.mockResolvedValue({ data: "lista-1", error: null });
 
-    await guardarListaActual();
-    expect(rpcMock).toHaveBeenCalledWith("guardar_lista_reposicion");
+    await guardarListaActual("tienda-test");
+    expect(rpcMock).toHaveBeenCalledWith("guardar_lista_reposicion", {
+      p_tienda_id: "tienda-test",
+    });
     expect(fromMock).not.toHaveBeenCalled();
   });
 
@@ -130,7 +132,7 @@ describe("guardarListaActual", () => {
     const { guardarListaActual } = await import("@/services/reposicion");
     rpcMock.mockResolvedValue({ data: null, error: new Error("No hay items para guardar") });
 
-    await expect(guardarListaActual()).rejects.toThrow("No hay items para guardar");
+    await expect(guardarListaActual("tienda-test")).rejects.toThrow("No hay items para guardar");
   });
 });
 
@@ -139,7 +141,7 @@ describe("obtenerHistorial", () => {
     const { obtenerHistorial } = await import("@/services/reposicion");
     fromMock.mockImplementation(mockSupabaseFrom({ data: [] }));
 
-    const listas = await obtenerHistorial();
+    const listas = await obtenerHistorial("tienda-test");
     expect(listas).toEqual([]);
     expect(fromMock).toHaveBeenCalledTimes(1); // no consulta items si no hay listas
   });
@@ -177,7 +179,7 @@ describe("obtenerHistorial", () => {
       )
     );
 
-    const listas = await obtenerHistorial();
+    const listas = await obtenerHistorial("tienda-test");
     expect(listas).toHaveLength(1);
     expect(listas[0].items).toHaveLength(1);
     expect(listas[0].resumen.totalRepuestos).toBe(1);

--- a/src/services/__tests__/vencimiento.test.ts
+++ b/src/services/__tests__/vencimiento.test.ts
@@ -41,7 +41,7 @@ describe("listarItems", () => {
     const { listarItems } = await import("@/services/vencimiento");
     fromMock.mockImplementation(mockSupabaseFrom({ data: [itemRow({ fecha_vencimiento: fechaISO(-3) })] }));
 
-    const items = await listarItems();
+    const items = await listarItems("tienda-test");
     expect(items[0].alertaNivel).toBe("vencido");
   });
 
@@ -49,7 +49,7 @@ describe("listarItems", () => {
     const { listarItems } = await import("@/services/vencimiento");
     fromMock.mockImplementation(mockSupabaseFrom({ data: [] }));
 
-    await listarItems();
+    await listarItems("tienda-test");
     expect(fromMock).toHaveBeenCalledWith("items_vencimiento");
   });
 });
@@ -136,7 +136,7 @@ describe("obtenerEstadisticas", () => {
       error: null,
     });
 
-    const stats = await obtenerEstadisticas("mes");
+    const stats = await obtenerEstadisticas("tienda-test", "mes");
     expect(rpcMock).toHaveBeenCalledWith(
       "obtener_estadisticas_vencimiento",
       expect.objectContaining({ p_desde: expect.any(String), p_hasta: expect.any(String) })
@@ -154,55 +154,22 @@ describe("obtenerEstadisticas", () => {
       error: Object.assign(new Error("boom"), { code: "XX000" }),
     });
 
-    await expect(obtenerEstadisticas("mes")).rejects.toThrow("boom");
+    await expect(obtenerEstadisticas("tienda-test", "mes")).rejects.toThrow("boom");
     expect(fromMock).not.toHaveBeenCalled();
   });
 
-  it("devuelve ceros cuando no hay retiros en el período (fallback client-side)", async () => {
+  it("propaga también PGRST202: el fallback client-side se eliminó en la Fase 2", async () => {
     const { obtenerEstadisticas } = await import("@/services/vencimiento");
     rpcMock.mockResolvedValue({
       data: null,
-      error: { code: "PGRST202", message: "function not found" },
+      error: Object.assign(new Error("function not found"), { code: "PGRST202" }),
     });
-    fromMock.mockImplementation(mockSupabaseFrom({ data: [] }));
 
-    const stats = await obtenerEstadisticas("mes");
-    expect(stats.totalRetirados).toBe(0);
-    expect(stats.promedioDiasARetiro).toBe(0);
-  });
-
-  it("cae al cálculo client-side si la RPC aún no existe (PGRST202)", async () => {
-    const { obtenerEstadisticas } = await import("@/services/vencimiento");
-    rpcMock.mockResolvedValue({
-      data: null,
-      error: { code: "PGRST202", message: "function not found" },
-    });
-    fromMock.mockImplementation(
-      mockSupabaseFrom({
-        data: [
-          {
-            id: "h1",
-            variante_id: "variante-1",
-            producto_nombre: "Leche",
-            producto_marca: "La Serenísima",
-            variante_nombre: "Leche 1L",
-            cantidad: 2,
-            lote: null,
-            fecha_vencimiento: "2026-01-01",
-            // Mediodía local (sin Z): fecha_vencimiento se parsea a medianoche
-            // local, así el diff da 2 días en cualquier huso horario. Con
-            // medianoche UTC el test fallaba en husos negativos (floor de 1.875).
-            fecha_retiro: "2026-01-03T12:00:00",
-            nivel_alerta_al_retirar: "critico",
-          },
-        ],
-      })
+    // La RPC existe siempre desde la migración 0015; un cálculo local
+    // post-scoping agregaría sobre todas las tiendas del usuario.
+    await expect(obtenerEstadisticas("tienda-test", "mes")).rejects.toThrow(
+      "function not found"
     );
-
-    const stats = await obtenerEstadisticas("mes");
-    // Cuenta unidades (cantidad), no filas: misma semántica que el top de productos.
-    expect(stats.totalRetirados).toBe(2);
-    expect(stats.promedioDiasARetiro).toBe(2); // retirado 2 días después de vencer
-    expect(stats.productosMasRetirados[0]).toEqual({ productoNombre: "Leche", cantidad: 2 });
+    expect(fromMock).not.toHaveBeenCalled();
   });
 });

--- a/src/services/catalogo.ts
+++ b/src/services/catalogo.ts
@@ -79,11 +79,16 @@ function mapProductoCompleto(row: ProductoVarianteConBaseRow): ProductoCompleto 
  * en el camino crítico de "escanear código").
  */
 export async function buscarPorCodigoBarras(
+  tiendaId: string,
   codigoBarras: string
 ): Promise<ProductoCompleto | null> {
+  // El filtro por tienda es obligatorio: el EAN es único POR TIENDA desde
+  // la Fase 2, y para un usuario multi-membresía el maybeSingle() fallaría
+  // con dos matches.
   const { data, error } = await supabase
     .from("producto_variantes")
     .select("*, producto_bases(*)")
+    .eq("tienda_id", tiendaId)
     .eq("codigo_barras", codigoBarras)
     .maybeSingle();
 
@@ -118,13 +123,17 @@ function sanitizarTerminoBusqueda(termino: string): string {
 }
 
 /** Busca productos base por nombre o marca (para autocompletado/administración liviana). */
-export async function buscarProductos(termino: string): Promise<ProductoBase[]> {
+export async function buscarProductos(
+  tiendaId: string,
+  termino: string
+): Promise<ProductoBase[]> {
   const limpio = sanitizarTerminoBusqueda(termino);
   if (limpio.length < 2) return [];
 
   const { data, error } = await supabase
     .from("producto_bases")
     .select("*")
+    .eq("tienda_id", tiendaId)
     .or(`nombre.ilike.%${limpio}%,marca.ilike.%${limpio}%`)
     .limit(20);
 
@@ -138,7 +147,10 @@ export async function buscarProductos(termino: string): Promise<ProductoBase[]> 
  * queries en paralelo (PostgREST no permite `.or()` cruzando la tabla
  * principal y la referenciada en la misma llamada) mergeadas por variante.id.
  */
-export async function buscarVariantes(termino: string): Promise<ProductoCompleto[]> {
+export async function buscarVariantes(
+  tiendaId: string,
+  termino: string
+): Promise<ProductoCompleto[]> {
   const limpio = sanitizarTerminoBusqueda(termino);
   if (limpio.length < 2) return [];
 
@@ -146,11 +158,13 @@ export async function buscarVariantes(termino: string): Promise<ProductoCompleto
     supabase
       .from("producto_variantes")
       .select("*, producto_bases(*)")
+      .eq("tienda_id", tiendaId)
       .ilike("nombre_completo", `%${limpio}%`)
       .limit(15),
     supabase
       .from("producto_variantes")
       .select("*, producto_bases!inner(*)")
+      .eq("tienda_id", tiendaId)
       .or(`nombre.ilike.%${limpio}%,marca.ilike.%${limpio}%`, {
         referencedTable: "producto_bases",
       })
@@ -189,12 +203,14 @@ function sanitizarAtributos(atributos?: AtributosVariante): AtributosVariante {
  * el mismo nombre + marca.
  */
 export async function crearProductoManual(
+  tiendaId: string,
   dto: CrearProductoDTO,
   client: SupabaseClient = supabase
 ): Promise<ProductoCompleto> {
   // Los dos checks de existencia son independientes entre sí: se disparan
   // en paralelo para no pagar dos round-trips secuenciales antes de poder
-  // crear el producto.
+  // crear el producto. Scoped a la tienda: el mismo EAN/base puede existir
+  // en otra tienda.
   const [
     { data: existente, error: buscarError },
     { data: baseExistente, error: baseBuscarError },
@@ -202,6 +218,7 @@ export async function crearProductoManual(
     client
       .from("producto_variantes")
       .select("id")
+      .eq("tienda_id", tiendaId)
       .eq("codigo_barras", dto.ean)
       .maybeSingle(),
     // ilike sin comodines = igualdad case-insensitive: reutiliza la base
@@ -210,6 +227,7 @@ export async function crearProductoManual(
     client
       .from("producto_bases")
       .select("*")
+      .eq("tienda_id", tiendaId)
       .ilike("nombre", dto.productoBase.nombre.trim())
       .ilike("marca", dto.productoBase.marca.trim())
       .maybeSingle(),
@@ -222,9 +240,12 @@ export async function crearProductoManual(
 
   let baseRow = baseExistente as ProductoBaseRow | null;
   if (!baseRow) {
+    // producto_bases es tabla raíz: tienda_id explícito (las variantes lo
+    // derivan por trigger desde la base).
     const { data, error } = await client
       .from("producto_bases")
       .insert({
+        tienda_id: tiendaId,
         nombre: dto.productoBase.nombre.trim(),
         marca: dto.productoBase.marca.trim(),
         categoria: dto.productoBase.categoria?.trim() || null,
@@ -307,11 +328,13 @@ export interface DefinicionesAtributos {
  * La tabla es diminuta (unas filas por categoría), se trae entera.
  */
 export async function obtenerDefinicionesAtributos(
+  tiendaId: string,
   client: SupabaseClient = supabase
 ): Promise<DefinicionesAtributos> {
   const { data, error } = await client
     .from("categoria_atributos")
     .select("categoria, clave, etiqueta, orden, sugerencias")
+    .eq("tienda_id", tiendaId)
     .order("orden");
   if (error) throw error;
 
@@ -334,6 +357,7 @@ export async function obtenerDefinicionesAtributos(
 
 /** Marcas y categorías existentes, para autocompletar el formulario de alta manual. */
 export async function obtenerMarcasYCategorias(
+  tiendaId: string,
   client: SupabaseClient = supabase
 ): Promise<{
   marcas: string[];
@@ -341,7 +365,8 @@ export async function obtenerMarcasYCategorias(
 }> {
   const { data, error } = await client
     .from("producto_bases")
-    .select("marca, categoria");
+    .select("marca, categoria")
+    .eq("tienda_id", tiendaId);
   if (error) throw error;
 
   const marcas = Array.from(
@@ -366,11 +391,13 @@ export interface CatalogoCompleto {
  * cachear entero en IndexedDB. Es la fuente para lookup/búsqueda offline
  * (ver src/lib/catalogoLocal.ts) — reemplaza N round-trips por 1 sync.
  */
-export async function obtenerCatalogoCompleto(): Promise<CatalogoCompleto> {
+export async function obtenerCatalogoCompleto(
+  tiendaId: string
+): Promise<CatalogoCompleto> {
   const [basesResult, variantesResult, definiciones] = await Promise.all([
-    supabase.from("producto_bases").select("*"),
-    supabase.from("producto_variantes").select("*"),
-    obtenerDefinicionesAtributos(),
+    supabase.from("producto_bases").select("*").eq("tienda_id", tiendaId),
+    supabase.from("producto_variantes").select("*").eq("tienda_id", tiendaId),
+    obtenerDefinicionesAtributos(tiendaId),
   ]);
   if (basesResult.error) throw basesResult.error;
   if (variantesResult.error) throw variantesResult.error;

--- a/src/services/parseoProducto.ts
+++ b/src/services/parseoProducto.ts
@@ -294,6 +294,7 @@ async function parsearConGemini(
  */
 export async function parsearProducto(
   texto: string,
+  tiendaId: string,
   client: SupabaseClient = supabase
 ): Promise<ProductoParseado> {
   const anthropicConfigurado = Boolean(process.env.ANTHROPIC_API_KEY);
@@ -302,15 +303,18 @@ export async function parsearProducto(
     throw new IANoConfiguradaError();
   }
 
+  // Todo el contexto del prompt (marcas, categorías, bases, definiciones)
+  // es de la tienda activa: el catálogo es privado por tienda.
   const [{ marcas, categorias }, defs, basesResult] = await Promise.all([
-    obtenerMarcasYCategorias(client),
-    obtenerDefinicionesAtributos(client),
+    obtenerMarcasYCategorias(tiendaId, client),
+    obtenerDefinicionesAtributos(tiendaId, client),
     // El orden estable importa: el system prompt se cachea por prefijo exacto
     // de bytes, y sin .order() Postgres no garantiza orden — cada request
     // generaría un prompt distinto y el caché nunca pegaría.
     client
       .from("producto_bases")
       .select("nombre, marca, categoria")
+      .eq("tienda_id", tiendaId)
       .order("nombre")
       .order("marca"),
   ]);

--- a/src/services/reposicion.ts
+++ b/src/services/reposicion.ts
@@ -83,10 +83,14 @@ function mapLista(
   };
 }
 
-export async function listarItems(): Promise<ItemReposicion[]> {
+// Las lecturas filtran por la tienda ACTIVA además de RLS: RLS scopea a
+// "todas mis tiendas", y para un usuario con más de una membresía eso
+// mezclaría listas de tiendas distintas.
+export async function listarItems(tiendaId: string): Promise<ItemReposicion[]> {
   const { data, error } = await supabase
     .from("items_reposicion")
     .select("*")
+    .eq("tienda_id", tiendaId)
     .order("agregado_at", { ascending: false });
   if (error) throw error;
   return (data ?? []).map((row) => mapItem(row as ItemReposicionRow));
@@ -180,19 +184,25 @@ export async function eliminarItemsMasivo(ids: string[]): Promise<void> {
  * insertar items de historial, borrar activos), con riesgo real de quedar
  * a mitad de camino si algún paso fallaba.
  */
-export async function guardarListaActual(): Promise<void> {
-  const { error } = await supabase.rpc("guardar_lista_reposicion");
+export async function guardarListaActual(tiendaId: string): Promise<void> {
+  const { error } = await supabase.rpc("guardar_lista_reposicion", {
+    p_tienda_id: tiendaId,
+  });
   if (error) throw error;
 }
 
-export async function obtenerHistorial(filtros?: {
-  desde?: Date;
-  hasta?: Date;
-  limite?: number;
-}): Promise<ListaReposicionHistorial[]> {
+export async function obtenerHistorial(
+  tiendaId: string,
+  filtros?: {
+    desde?: Date;
+    hasta?: Date;
+    limite?: number;
+  }
+): Promise<ListaReposicionHistorial[]> {
   let query = supabase
     .from("listas_reposicion_historial")
     .select("*")
+    .eq("tienda_id", tiendaId)
     .order("fecha_guardado", { ascending: false });
 
   if (filtros?.desde) query = query.gte("fecha_guardado", filtros.desde.toISOString());
@@ -233,6 +243,7 @@ export async function eliminarListaHistorial(id: string): Promise<void> {
 }
 
 export async function obtenerEstadisticas(
+  tiendaId: string,
   periodo: "semana" | "mes" | "año"
 ): Promise<EstadisticasReposicion> {
   const ahora = new Date();
@@ -249,7 +260,7 @@ export async function obtenerEstadisticas(
       break;
   }
 
-  const listas = await obtenerHistorial({ desde: fechaInicio, hasta: ahora });
+  const listas = await obtenerHistorial(tiendaId, { desde: fechaInicio, hasta: ahora });
 
   if (listas.length === 0) {
     return {

--- a/src/services/vencimiento.ts
+++ b/src/services/vencimiento.ts
@@ -64,11 +64,16 @@ function mapHistorial(row: ItemVencimientoHistorialRow): ItemVencimientoHistoria
   };
 }
 
-/** Lista los items de vencimiento activos (pendientes), con el nivel de alerta calculado. */
-export async function listarItems(): Promise<ItemVencimientoConAlerta[]> {
+/**
+ * Lista los items de vencimiento activos (pendientes), con el nivel de
+ * alerta calculado. Filtra por la tienda ACTIVA además de RLS (que scopea
+ * a "todas mis tiendas" y mezclaría listas en usuarios multi-membresía).
+ */
+export async function listarItems(tiendaId: string): Promise<ItemVencimientoConAlerta[]> {
   const { data, error } = await supabase
     .from("items_vencimiento")
     .select("*")
+    .eq("tienda_id", tiendaId)
     .eq("estado", "pendiente")
     .order("fecha_vencimiento", { ascending: true });
   if (error) throw error;
@@ -163,14 +168,18 @@ export async function retirarItemsMasivo(ids: string[]): Promise<void> {
   throw error;
 }
 
-export async function obtenerHistorial(filtros?: {
-  desde?: Date;
-  hasta?: Date;
-  limite?: number;
-}): Promise<ItemVencimientoHistorial[]> {
+export async function obtenerHistorial(
+  tiendaId: string,
+  filtros?: {
+    desde?: Date;
+    hasta?: Date;
+    limite?: number;
+  }
+): Promise<ItemVencimientoHistorial[]> {
   let query = supabase
     .from("items_vencimiento_historial")
     .select("*")
+    .eq("tienda_id", tiendaId)
     .order("fecha_retiro", { ascending: false });
 
   if (filtros?.desde) query = query.gte("fecha_retiro", filtros.desde.toISOString());
@@ -197,6 +206,7 @@ interface EstadisticasRpcResult {
  * que el top de productos.
  */
 export async function obtenerEstadisticas(
+  tiendaId: string,
   periodo: "semana" | "mes" | "año"
 ): Promise<EstadisticasVencimiento> {
   const ahora = new Date();
@@ -213,70 +223,24 @@ export async function obtenerEstadisticas(
       break;
   }
 
+  // Sin fallback client-side desde la Fase 2: la RPC existe siempre
+  // (migración 0015) y un cálculo local post-scoping agregaría sobre todas
+  // mis tiendas en vez de la activa.
   const { data, error } = await supabase.rpc("obtener_estadisticas_vencimiento", {
+    p_tienda_id: tiendaId,
     p_desde: fechaInicio.toISOString(),
     p_hasta: ahora.toISOString(),
   });
+  if (error) throw error;
 
-  if (!error) {
-    const stats = data as EstadisticasRpcResult;
-    return {
-      periodo,
-      totalRetirados: stats.total_retirados,
-      promedioDiasARetiro: Number(stats.promedio_dias_a_retiro),
-      productosMasRetirados: (stats.productos_mas_retirados ?? []).map((p) => ({
-        productoNombre: p.producto_nombre,
-        cantidad: p.cantidad,
-      })),
-    };
-  }
-
-  // PGRST202: la RPC todavía no existe (migración 0011 sin aplicar).
-  // Fallback al cálculo client-side para no depender del orden de deploy.
-  if (error.code !== "PGRST202") throw error;
-  return obtenerEstadisticasClientSide(periodo, fechaInicio, ahora);
-}
-
-async function obtenerEstadisticasClientSide(
-  periodo: "semana" | "mes" | "año",
-  desde: Date,
-  hasta: Date
-): Promise<EstadisticasVencimiento> {
-  const retirados = await obtenerHistorial({ desde, hasta });
-
-  if (retirados.length === 0) {
-    return {
-      periodo,
-      totalRetirados: 0,
-      productosMasRetirados: [],
-      promedioDiasARetiro: 0,
-    };
-  }
-
-  const productosCount = new Map<string, number>();
-  let totalUnidades = 0;
-  let sumaDias = 0;
-  retirados.forEach((item) => {
-    const unidades = item.cantidad ?? 1;
-    totalUnidades += unidades;
-    const count = productosCount.get(item.productoNombre) || 0;
-    productosCount.set(item.productoNombre, count + unidades);
-
-    const dias = Math.floor(
-      (item.fechaRetiro.getTime() - item.fechaVencimiento.getTime()) / (1000 * 60 * 60 * 24)
-    );
-    sumaDias += dias;
-  });
-
-  const productosMasRetirados = Array.from(productosCount.entries())
-    .map(([productoNombre, cantidad]) => ({ productoNombre, cantidad }))
-    .sort((a, b) => b.cantidad - a.cantidad)
-    .slice(0, 10);
-
+  const stats = data as EstadisticasRpcResult;
   return {
     periodo,
-    totalRetirados: totalUnidades,
-    productosMasRetirados,
-    promedioDiasARetiro: sumaDias / retirados.length,
+    totalRetirados: stats.total_retirados,
+    promedioDiasARetiro: Number(stats.promedio_dias_a_retiro),
+    productosMasRetirados: (stats.productos_mas_retirados ?? []).map((p) => ({
+      productoNombre: p.producto_nombre,
+      cantidad: p.cantidad,
+    })),
   };
 }

--- a/src/store/__tests__/recents.test.ts
+++ b/src/store/__tests__/recents.test.ts
@@ -1,40 +1,62 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRecentsStore, useRecientes, useFrecuentes } from "../recents";
 import { renderHook } from "@testing-library/react";
+
+const TIENDA = "tienda-test";
+
+// Los selectores leen la tienda activa del AuthProvider.
+vi.mock("@/components/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: "user-test" },
+    cargando: false,
+    tiendaActiva: TIENDA,
+    rol: "admin",
+  }),
+}));
 
 describe("recents store", () => {
   beforeEach(() => {
     useRecentsStore.setState({ entries: {} });
   });
 
-  it("registrarUso crea una entrada nueva con count 1", () => {
+  it("registrarUso crea una entrada nueva con count 1 en la tienda", () => {
     useRecentsStore
       .getState()
-      .registrarUso({ varianteId: "v1", nombre: "Leche", marca: "La Serenísima" });
+      .registrarUso(TIENDA, { varianteId: "v1", nombre: "Leche", marca: "La Serenísima" });
 
-    const entry = useRecentsStore.getState().entries["v1"];
+    const entry = useRecentsStore.getState().entries[TIENDA]["v1"];
     expect(entry.count).toBe(1);
     expect(entry.nombre).toBe("Leche");
   });
 
   it("registrarUso de nuevo sobre el mismo producto suma count y actualiza lastUsed", async () => {
-    useRecentsStore.getState().registrarUso({ varianteId: "v1", nombre: "Leche" });
-    const primerUso = useRecentsStore.getState().entries["v1"].lastUsed;
+    useRecentsStore.getState().registrarUso(TIENDA, { varianteId: "v1", nombre: "Leche" });
+    const primerUso = useRecentsStore.getState().entries[TIENDA]["v1"].lastUsed;
 
     await new Promise((r) => setTimeout(r, 5));
-    useRecentsStore.getState().registrarUso({ varianteId: "v1", nombre: "Leche" });
+    useRecentsStore.getState().registrarUso(TIENDA, { varianteId: "v1", nombre: "Leche" });
 
-    const entry = useRecentsStore.getState().entries["v1"];
+    const entry = useRecentsStore.getState().entries[TIENDA]["v1"];
     expect(entry.count).toBe(2);
     expect(entry.lastUsed).toBeGreaterThanOrEqual(primerUso);
+  });
+
+  it("las entradas de otra tienda no aparecen en los selectores", () => {
+    useRecentsStore.getState().registrarUso("otra-tienda", { varianteId: "vx", nombre: "Ajena" });
+    useRecentsStore.getState().registrarUso(TIENDA, { varianteId: "v1", nombre: "Propia" });
+
+    const { result } = renderHook(() => useRecientes());
+    expect(result.current.map((e) => e.varianteId)).toEqual(["v1"]);
   });
 
   it("useRecientes ordena por lastUsed descendente", () => {
     useRecentsStore.setState({
       entries: {
-        v1: { varianteId: "v1", nombre: "A", count: 1, lastUsed: 100 },
-        v2: { varianteId: "v2", nombre: "B", count: 1, lastUsed: 300 },
-        v3: { varianteId: "v3", nombre: "C", count: 1, lastUsed: 200 },
+        [TIENDA]: {
+          v1: { varianteId: "v1", nombre: "A", count: 1, lastUsed: 100 },
+          v2: { varianteId: "v2", nombre: "B", count: 1, lastUsed: 300 },
+          v3: { varianteId: "v3", nombre: "C", count: 1, lastUsed: 200 },
+        },
       },
     });
 
@@ -45,9 +67,11 @@ describe("recents store", () => {
   it("useFrecuentes ordena por count descendente", () => {
     useRecentsStore.setState({
       entries: {
-        v1: { varianteId: "v1", nombre: "A", count: 5, lastUsed: 100 },
-        v2: { varianteId: "v2", nombre: "B", count: 1, lastUsed: 300 },
-        v3: { varianteId: "v3", nombre: "C", count: 9, lastUsed: 200 },
+        [TIENDA]: {
+          v1: { varianteId: "v1", nombre: "A", count: 5, lastUsed: 100 },
+          v2: { varianteId: "v2", nombre: "B", count: 1, lastUsed: 300 },
+          v3: { varianteId: "v3", nombre: "C", count: 9, lastUsed: 200 },
+        },
       },
     });
 
@@ -58,9 +82,11 @@ describe("recents store", () => {
   it("useRecientes respeta el límite pasado", () => {
     useRecentsStore.setState({
       entries: {
-        v1: { varianteId: "v1", nombre: "A", count: 1, lastUsed: 1 },
-        v2: { varianteId: "v2", nombre: "B", count: 1, lastUsed: 2 },
-        v3: { varianteId: "v3", nombre: "C", count: 1, lastUsed: 3 },
+        [TIENDA]: {
+          v1: { varianteId: "v1", nombre: "A", count: 1, lastUsed: 1 },
+          v2: { varianteId: "v2", nombre: "B", count: 1, lastUsed: 2 },
+          v3: { varianteId: "v3", nombre: "C", count: 1, lastUsed: 3 },
+        },
       },
     });
 

--- a/src/store/recents.ts
+++ b/src/store/recents.ts
@@ -1,3 +1,6 @@
+"use client";
+
+import { useAuth } from "@/components/AuthProvider";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -11,13 +14,18 @@ export interface RecentEntry {
 }
 
 interface RecentsState {
-  entries: Record<string, RecentEntry>;
-  registrarUso: (p: {
-    varianteId: string;
-    nombre: string;
-    marca?: string;
-    tamano?: string;
-  }) => void;
+  /** Entradas por tienda (Fase 2 multi-tienda, spec §4.4): los recientes
+   * de una tienda no aparecen en otra. */
+  entries: Record<string, Record<string, RecentEntry>>;
+  registrarUso: (
+    tiendaId: string,
+    p: {
+      varianteId: string;
+      nombre: string;
+      marca?: string;
+      tamano?: string;
+    }
+  ) => void;
 }
 
 const MAX_ENTRADAS = 40;
@@ -26,11 +34,12 @@ export const useRecentsStore = create<RecentsState>()(
   persist(
     (set) => ({
       entries: {},
-      registrarUso: (p) =>
+      registrarUso: (tiendaId, p) =>
         set((s) => {
-          const previo = s.entries[p.varianteId];
-          const entries = {
-            ...s.entries,
+          const deTienda = s.entries[tiendaId] ?? {};
+          const previo = deTienda[p.varianteId];
+          const actualizadas = {
+            ...deTienda,
             [p.varianteId]: {
               varianteId: p.varianteId,
               nombre: p.nombre,
@@ -42,30 +51,44 @@ export const useRecentsStore = create<RecentsState>()(
           };
           // Recorte simple: si crece demasiado, tirar las menos usadas
           // recientemente (client-side, no hace falta ser preciso).
-          const claves = Object.keys(entries);
+          const claves = Object.keys(actualizadas);
           if (claves.length > MAX_ENTRADAS) {
             const aBorrar = claves
-              .map((k) => entries[k])
+              .map((k) => actualizadas[k])
               .sort((a, b) => a.lastUsed - b.lastUsed)
               .slice(0, claves.length - MAX_ENTRADAS);
-            for (const e of aBorrar) delete entries[e.varianteId];
+            for (const e of aBorrar) delete actualizadas[e.varianteId];
           }
-          return { entries };
+          return { entries: { ...s.entries, [tiendaId]: actualizadas } };
         }),
     }),
-    { name: "gondolapp-recents" }
+    {
+      name: "gondolapp-recents",
+      // v1: entries pasa de plano (por variante) a anidado (por tienda).
+      // El shape viejo no sabe de qué tienda era: se descarta.
+      version: 1,
+      migrate: () => ({ entries: {} }) as RecentsState,
+    }
   )
 );
 
-export function useRecientes(limit = 8): RecentEntry[] {
+const SIN_ENTRADAS: Record<string, RecentEntry> = {};
+
+function useEntradasDeTienda(): Record<string, RecentEntry> {
+  const { tiendaActiva } = useAuth();
   const entries = useRecentsStore((s) => s.entries);
+  return (tiendaActiva && entries[tiendaActiva]) || SIN_ENTRADAS;
+}
+
+export function useRecientes(limit = 8): RecentEntry[] {
+  const entries = useEntradasDeTienda();
   return Object.values(entries)
     .sort((a, b) => b.lastUsed - a.lastUsed)
     .slice(0, limit);
 }
 
 export function useFrecuentes(limit = 8): RecentEntry[] {
-  const entries = useRecentsStore((s) => s.entries);
+  const entries = useEntradasDeTienda();
   return Object.values(entries)
     .sort((a, b) => b.count - a.count)
     .slice(0, limit);

--- a/src/store/sesion.ts
+++ b/src/store/sesion.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type RolTienda = "admin" | "empleado";
+
+interface SesionState {
+  /** Tienda activa persistida: necesaria para el buster del cache y las
+   * query keys en arranque frío offline, cuando la membresía no se puede
+   * consultar (docs/SPECMULTIUSER.md §4.4). */
+  tiendaActivaId: string | null;
+  rol: RolTienda | null;
+  setTienda: (tiendaId: string | null, rol: RolTienda | null) => void;
+}
+
+export const useSesionStore = create<SesionState>()(
+  persist(
+    (set) => ({
+      tiendaActivaId: null,
+      rol: null,
+      setTienda: (tiendaId, rol) => set({ tiendaActivaId: tiendaId, rol }),
+    }),
+    { name: "gondolapp-sesion" }
+  )
+);

--- a/src/tests/integration/aislamiento-rls.test.ts
+++ b/src/tests/integration/aislamiento-rls.test.ts
@@ -1,0 +1,356 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  crearClienteAdmin,
+  crearUsuarioDePrueba,
+  eliminarUsuarioDePrueba,
+  verificarConfiguracion,
+  UsuarioDePrueba,
+} from "./helpers";
+
+/**
+ * Suite de aislamiento RLS — el gate de la Fase 2 (docs/SPECMULTIUSER.md
+ * §2.4): dos usuarios × dos tiendas, por tabla × operación, las RPCs con
+ * ids ajenos y el caso multi-membresía de guardar_lista_reposicion.
+ *
+ * Corre contra un stack real con las migraciones 0001–0015 aplicadas
+ * (`supabase start` + `supabase db reset`); ver docs/TESTING.md.
+ */
+
+let admin: SupabaseClient;
+let userA: UsuarioDePrueba; // admin de tienda A
+let userB: UsuarioDePrueba; // admin de tienda B; luego empleado de A (canje)
+let tiendaA: string;
+let tiendaB: string;
+let varianteA: string; // variante del catálogo de A
+let varianteB: string;
+let itemReposicionA: string; // item de reposición pendiente en A
+let itemVencimientoA: string;
+
+async function crearCatalogo(
+  client: SupabaseClient,
+  tiendaId: string,
+  nombre: string,
+  ean: string
+): Promise<string> {
+  const { data: base, error: baseError } = await client
+    .from("producto_bases")
+    .insert({ tienda_id: tiendaId, nombre, marca: "MarcaTest" })
+    .select("id")
+    .single();
+  if (baseError) throw baseError;
+  const { data: variante, error: varError } = await client
+    .from("producto_variantes")
+    .insert({ producto_base_id: base.id, codigo_barras: ean, atributos: {} })
+    .select("id")
+    .single();
+  if (varError) throw varError;
+  return variante.id as string;
+}
+
+/** Borra todo lo de una tienda con service_role (bypasea RLS y triggers de invoker). */
+async function limpiarTienda(tiendaId: string): Promise<void> {
+  for (const tabla of [
+    "items_reposicion",
+    "items_vencimiento",
+    "items_reposicion_historial",
+    "listas_reposicion_historial",
+    "items_vencimiento_historial",
+    "producto_variantes",
+    "producto_bases",
+    "categoria_atributos",
+  ]) {
+    await admin.from(tabla).delete().eq("tienda_id", tiendaId);
+  }
+  await admin.from("tiendas").delete().eq("id", tiendaId);
+}
+
+beforeAll(async () => {
+  verificarConfiguracion();
+  admin = crearClienteAdmin();
+  userA = await crearUsuarioDePrueba(admin, "rls-a");
+  userB = await crearUsuarioDePrueba(admin, "rls-b");
+
+  const { data: tA, error: eA } = await userA.client.rpc("crear_tienda_con_admin", {
+    p_nombre: "Tienda A",
+  });
+  if (eA) throw eA;
+  tiendaA = tA as string;
+
+  const { data: tB, error: eB } = await userB.client.rpc("crear_tienda_con_admin", {
+    p_nombre: "Tienda B",
+  });
+  if (eB) throw eB;
+  tiendaB = tB as string;
+
+  varianteA = await crearCatalogo(userA.client, tiendaA, "Leche A", "7790000000001");
+  varianteB = await crearCatalogo(userB.client, tiendaB, "Leche B", "7790000000002");
+
+  const { data: item, error: itemError } = await userA.client.rpc(
+    "agregar_item_reposicion",
+    { p_variante_id: varianteA, p_cantidad: 2 }
+  );
+  if (itemError) throw itemError;
+  itemReposicionA = (item as { id: string }).id;
+
+  const { data: venc, error: vencError } = await userA.client
+    .from("items_vencimiento")
+    .insert({ variante_id: varianteA, fecha_vencimiento: "2030-01-01" })
+    .select("id")
+    .single();
+  if (vencError) throw vencError;
+  itemVencimientoA = venc.id as string;
+}, 60_000);
+
+afterAll(async () => {
+  if (tiendaA) await limpiarTienda(tiendaA);
+  if (tiendaB) await limpiarTienda(tiendaB);
+  if (userA) await eliminarUsuarioDePrueba(admin, userA);
+  if (userB) await eliminarUsuarioDePrueba(admin, userB);
+}, 60_000);
+
+describe("aislamiento por tabla", () => {
+  it("SELECT: B no ve el catálogo ni las listas de A", async () => {
+    for (const tabla of [
+      "producto_bases",
+      "producto_variantes",
+      "categoria_atributos",
+      "items_reposicion",
+      "items_vencimiento",
+    ]) {
+      const { data, error } = await userB.client
+        .from(tabla)
+        .select("id")
+        .eq("tienda_id", tiendaA);
+      expect(error, tabla).toBeNull();
+      expect(data, tabla).toEqual([]);
+    }
+  });
+
+  it("SELECT: cada uno ve lo suyo", async () => {
+    const { data: propioA } = await userA.client
+      .from("producto_variantes")
+      .select("id")
+      .eq("tienda_id", tiendaA);
+    expect(propioA).toHaveLength(1);
+    const { data: propioB } = await userB.client
+      .from("producto_variantes")
+      .select("id")
+      .eq("tienda_id", tiendaB);
+    expect(propioB).toHaveLength(1);
+  });
+
+  it("INSERT: B no puede crear una base con tienda_id de A (WITH CHECK)", async () => {
+    const { error } = await userB.client
+      .from("producto_bases")
+      .insert({ tienda_id: tiendaA, nombre: "Intrusa", marca: "X" });
+    expect(error).not.toBeNull();
+  });
+
+  it("INSERT: B no puede crear un item apuntando a una variante de A (trigger de derivación)", async () => {
+    const { error } = await userB.client
+      .from("items_reposicion")
+      .insert({ variante_id: varianteA, cantidad: 1, estado: "pendiente" });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/fuera de tus tiendas|inexistente/i);
+  });
+
+  it("UPDATE/DELETE: B no modifica ni borra items de A (0 filas afectadas)", async () => {
+    const { data: actualizado } = await userB.client
+      .from("items_reposicion")
+      .update({ cantidad: 99 })
+      .eq("id", itemReposicionA)
+      .select();
+    expect(actualizado).toEqual([]);
+
+    await userB.client.from("items_reposicion").delete().eq("id", itemReposicionA);
+    const { data: sigueVivo } = await userA.client
+      .from("items_reposicion")
+      .select("id, cantidad")
+      .eq("id", itemReposicionA)
+      .single();
+    expect(sigueVivo).not.toBeNull();
+    expect(sigueVivo!.cantidad).toBe(2);
+  });
+});
+
+describe("RPCs con ids ajenos", () => {
+  it("agregar_item_reposicion con variante de A falla para B", async () => {
+    const { error } = await userB.client.rpc("agregar_item_reposicion", {
+      p_variante_id: varianteA,
+      p_cantidad: 1,
+    });
+    expect(error).not.toBeNull();
+  });
+
+  it("retirar_item_vencimiento con item de A falla para B", async () => {
+    const { error } = await userB.client.rpc("retirar_item_vencimiento", {
+      p_item_id: itemVencimientoA,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/no encontrado/i);
+  });
+
+  it("retirar_items_vencimiento con ids de A no borra nada", async () => {
+    const { error } = await userB.client.rpc("retirar_items_vencimiento", {
+      p_item_ids: [itemVencimientoA],
+    });
+    expect(error).toBeNull(); // set-based: los ajenos simplemente no matchean
+    const { data } = await userA.client
+      .from("items_vencimiento")
+      .select("id")
+      .eq("id", itemVencimientoA);
+    expect(data).toHaveLength(1);
+  });
+
+  it("guardar_lista_reposicion de la tienda A falla para B (no miembro)", async () => {
+    const { error } = await userB.client.rpc("guardar_lista_reposicion", {
+      p_tienda_id: tiendaA,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/no sos miembro/i);
+  });
+
+  it("obtener_estadisticas_vencimiento de A devuelve vacío para B", async () => {
+    const { data, error } = await userB.client.rpc(
+      "obtener_estadisticas_vencimiento",
+      {
+        p_tienda_id: tiendaA,
+        p_desde: "2000-01-01T00:00:00Z",
+        p_hasta: "2100-01-01T00:00:00Z",
+      }
+    );
+    expect(error).toBeNull();
+    expect((data as { total_retirados: number }).total_retirados).toBe(0);
+  });
+
+  it("generar_codigo_invitacion de A falla para B (no admin de A)", async () => {
+    const { error } = await userB.client.rpc("generar_codigo_invitacion", {
+      p_tienda_id: tiendaA,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/admin/i);
+  });
+});
+
+describe("invitaciones y multi-membresía", () => {
+  let codigo: string;
+
+  it("el admin de A genera un código y B lo canjea (queda empleado de A)", async () => {
+    const { data, error } = await userA.client.rpc("generar_codigo_invitacion", {
+      p_tienda_id: tiendaA,
+      p_rol: "empleado",
+      p_max_usos: 1,
+      p_dias: 1,
+    });
+    expect(error).toBeNull();
+    codigo = data as string;
+    expect(codigo).toHaveLength(8);
+
+    const { data: tienda, error: canjeError } = await userB.client.rpc(
+      "canjear_invitacion",
+      { p_codigo: codigo }
+    );
+    expect(canjeError).toBeNull();
+    expect(tienda).toBe(tiendaA);
+  });
+
+  it("re-canjear siendo miembro no quema usos y un tercero ya no entra", async () => {
+    // B ya es miembro: re-canje idempotente.
+    const { error: reCanje } = await userB.client.rpc("canjear_invitacion", {
+      p_codigo: codigo,
+    });
+    expect(reCanje).toBeNull();
+
+    // El único uso lo consumió B: un tercero es rechazado.
+    const userC = await crearUsuarioDePrueba(admin, "rls-c");
+    try {
+      const { error } = await userC.client.rpc("canjear_invitacion", {
+        p_codigo: codigo,
+      });
+      expect(error).not.toBeNull();
+      expect(error!.message).toMatch(/inválido|vencido|agotado/i);
+    } finally {
+      await eliminarUsuarioDePrueba(admin, userC);
+    }
+  });
+
+  it("un código revocado no se puede canjear", async () => {
+    const { data: nuevo } = await userA.client.rpc("generar_codigo_invitacion", {
+      p_tienda_id: tiendaA,
+    });
+    await userA.client
+      .from("tienda_invitaciones")
+      .update({ revocada: true })
+      .eq("codigo", nuevo as string);
+
+    const userC = await crearUsuarioDePrueba(admin, "rls-d");
+    try {
+      const { error } = await userC.client.rpc("canjear_invitacion", {
+        p_codigo: nuevo as string,
+      });
+      expect(error).not.toBeNull();
+    } finally {
+      await eliminarUsuarioDePrueba(admin, userC);
+    }
+  });
+
+  it("multi-membresía: guardar la lista de A no toca los items de B", async () => {
+    // B (ahora miembro de A y de B) tiene pendientes en ambas tiendas.
+    const { error: aggError } = await userB.client.rpc("agregar_item_reposicion", {
+      p_variante_id: varianteB,
+      p_cantidad: 5,
+    });
+    expect(aggError).toBeNull();
+
+    const { error: guardarError } = await userB.client.rpc(
+      "guardar_lista_reposicion",
+      { p_tienda_id: tiendaA }
+    );
+    expect(guardarError).toBeNull();
+
+    // Los items de A se archivaron…
+    const { data: itemsA } = await userB.client
+      .from("items_reposicion")
+      .select("id")
+      .eq("tienda_id", tiendaA);
+    expect(itemsA).toEqual([]);
+    // …y los de B siguen pendientes (el WHERE por tienda de la RPC).
+    const { data: itemsB } = await userB.client
+      .from("items_reposicion")
+      .select("id")
+      .eq("tienda_id", tiendaB);
+    expect(itemsB).toHaveLength(1);
+  });
+
+  it("un empleado no puede borrar historial (delete admin-only)", async () => {
+    // El guardado anterior dejó una lista en el historial de A. B es
+    // empleado de A: puede verla pero no borrarla.
+    const { data: listas } = await userB.client
+      .from("listas_reposicion_historial")
+      .select("id")
+      .eq("tienda_id", tiendaA);
+    expect(listas!.length).toBeGreaterThan(0);
+
+    await userB.client
+      .from("listas_reposicion_historial")
+      .delete()
+      .eq("id", listas![0].id);
+    const { data: sigue } = await userA.client
+      .from("listas_reposicion_historial")
+      .select("id")
+      .eq("id", listas![0].id);
+    expect(sigue).toHaveLength(1);
+  });
+
+  it("el mismo EAN es creable en dos tiendas (unicidad por tienda)", async () => {
+    // El EAN de la variante de A, creado en B: debe pasar.
+    const varianteId = await crearCatalogo(
+      userB.client,
+      tiendaB,
+      "Leche Clon",
+      "7790000000001"
+    );
+    expect(varianteId).toBeTruthy();
+  });
+});

--- a/supabase/migrations/0013_constraints_por_tienda.sql
+++ b/supabase/migrations/0013_constraints_por_tienda.sql
@@ -1,0 +1,126 @@
+-- Fase 2 multi-tienda (1/3): constraints e índices por tienda + triggers de
+-- derivación incondicional de tienda_id (docs/SPECMULTIUSER.md §1.2, §1.3).
+--
+-- La derivación es INCONDICIONAL a propósito: ignora cualquier tienda_id
+-- que envíe el cliente. El WITH CHECK de RLS valida membresía, no
+-- consistencia — sin esto, un usuario miembro de dos tiendas podría crear
+-- un item con tienda_id=B y variante de A. Como los triggers corren en el
+-- contexto del invoker, el SELECT de derivación está sujeto a RLS: una
+-- variante ajena devuelve NULL y el insert falla acá mismo.
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Funciones de derivación
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- producto_variantes ← producto_bases
+create or replace function derivar_tienda_desde_base() returns trigger
+language plpgsql set search_path = public as $$
+begin
+  select tienda_id into new.tienda_id
+    from producto_bases where id = new.producto_base_id;
+  if new.tienda_id is null then
+    raise exception 'producto base inexistente o fuera de tus tiendas: %', new.producto_base_id;
+  end if;
+  return new;
+end; $$;
+
+-- items_reposicion / items_vencimiento / items_vencimiento_historial ← producto_variantes
+create or replace function derivar_tienda_desde_variante() returns trigger
+language plpgsql set search_path = public as $$
+begin
+  select tienda_id into new.tienda_id
+    from producto_variantes where id = new.variante_id;
+  if new.tienda_id is null then
+    raise exception 'variante inexistente o fuera de tus tiendas: %', new.variante_id;
+  end if;
+  return new;
+end; $$;
+
+-- items_reposicion_historial ← listas_reposicion_historial
+create or replace function derivar_tienda_desde_lista() returns trigger
+language plpgsql set search_path = public as $$
+begin
+  select tienda_id into new.tienda_id
+    from listas_reposicion_historial where id = new.lista_id;
+  if new.tienda_id is null then
+    raise exception 'lista inexistente o fuera de tus tiendas: %', new.lista_id;
+  end if;
+  return new;
+end; $$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Triggers BEFORE INSERT.
+--    En producto_variantes conviven con trg_producto_variantes_nombre_completo
+--    (BEFORE INSERT OR UPDATE): Postgres dispara triggers del mismo evento
+--    en orden alfabético y "derivar" < "nombre", así que tienda_id ya está
+--    seteado cuando set_nombre_completo() lo necesita (migración 0015).
+-- ─────────────────────────────────────────────────────────────────────────
+
+create trigger trg_producto_variantes_derivar_tienda
+  before insert on producto_variantes
+  for each row execute function derivar_tienda_desde_base();
+
+create trigger trg_items_reposicion_derivar_tienda
+  before insert on items_reposicion
+  for each row execute function derivar_tienda_desde_variante();
+
+create trigger trg_items_vencimiento_derivar_tienda
+  before insert on items_vencimiento
+  for each row execute function derivar_tienda_desde_variante();
+
+create trigger trg_items_vencimiento_historial_derivar_tienda
+  before insert on items_vencimiento_historial
+  for each row execute function derivar_tienda_desde_variante();
+
+create trigger trg_items_reposicion_historial_derivar_tienda
+  before insert on items_reposicion_historial
+  for each row execute function derivar_tienda_desde_lista();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. Unicidad por tienda (§1.3): el mismo EAN / la misma base / la misma
+--    clave de atributo pueden existir en dos tiendas distintas.
+--    El índice parcial items_reposicion_pendiente_por_variante_uq NO se
+--    toca: una variante pertenece a una sola tienda, ya es único por
+--    tienda, y es el target del ON CONFLICT de agregar_item_reposicion.
+-- ─────────────────────────────────────────────────────────────────────────
+
+alter table producto_variantes drop constraint producto_variantes_codigo_barras_key;
+create unique index producto_variantes_tienda_codigo_uq
+  on producto_variantes (tienda_id, codigo_barras);
+
+drop index producto_bases_nombre_marca_uq;
+create unique index producto_bases_nombre_marca_uq
+  on producto_bases (tienda_id, lower(trim(nombre)), lower(trim(coalesce(marca, ''))));
+
+drop index categoria_atributos_categoria_clave_uq;
+create unique index categoria_atributos_categoria_clave_uq
+  on categoria_atributos (tienda_id, coalesce(categoria, ''), clave);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 4. Índices compuestos de hot paths (las policies filtran por tienda_id
+--    y las queries de listas por estado/fecha).
+-- ─────────────────────────────────────────────────────────────────────────
+
+create index idx_items_reposicion_tienda_estado
+  on items_reposicion (tienda_id, estado);
+create index idx_items_vencimiento_tienda_estado_fecha
+  on items_vencimiento (tienda_id, estado, fecha_vencimiento);
+create index idx_listas_reposicion_historial_tienda_fecha
+  on listas_reposicion_historial (tienda_id, fecha_guardado desc);
+create index idx_items_vencimiento_historial_tienda_fecha
+  on items_vencimiento_historial (tienda_id, fecha_retiro desc);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 5. Fin de la ventana de transición de la Fase 1: los DEFAULT ya no hacen
+--    falta (los triggers derivan; producto_bases y categoria_atributos
+--    reciben tienda_id explícito del route/RPC).
+-- ─────────────────────────────────────────────────────────────────────────
+
+alter table producto_bases alter column tienda_id drop default;
+alter table producto_variantes alter column tienda_id drop default;
+alter table categoria_atributos alter column tienda_id drop default;
+alter table items_reposicion alter column tienda_id drop default;
+alter table listas_reposicion_historial alter column tienda_id drop default;
+alter table items_reposicion_historial alter column tienda_id drop default;
+alter table items_vencimiento alter column tienda_id drop default;
+alter table items_vencimiento_historial alter column tienda_id drop default;

--- a/supabase/migrations/0014_rls_por_tienda.sql
+++ b/supabase/migrations/0014_rls_por_tienda.sql
@@ -1,0 +1,170 @@
+-- Fase 2 multi-tienda (2/3): RLS real por membresía (docs/SPECMULTIUSER.md
+-- §2.1, §2.2). Reemplaza el RLS intermedio de la Fase 1 (allow_all para
+-- authenticated) por policies por tienda en las 11 tablas.
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Helpers SECURITY DEFINER (§2.1). Evitan la recursión en las policies
+--    de tienda_miembros y unifican el patrón. La forma
+--    `col in (select mis_tiendas())` se evalúa una vez por statement
+--    (InitPlan); auth.uid() va envuelto en (select ...) por el mismo motivo.
+-- ─────────────────────────────────────────────────────────────────────────
+
+create or replace function public.mis_tiendas() returns setof uuid
+language sql stable security definer set search_path = public as
+$$ select tienda_id from tienda_miembros where user_id = (select auth.uid()) $$;
+
+create or replace function public.mis_tiendas_admin() returns setof uuid
+language sql stable security definer set search_path = public as
+$$ select tienda_id from tienda_miembros where user_id = (select auth.uid()) and rol = 'admin' $$;
+
+revoke execute on function mis_tiendas() from public, anon;
+revoke execute on function mis_tiendas_admin() from public, anon;
+grant execute on function mis_tiendas() to authenticated, service_role;
+grant execute on function mis_tiendas_admin() to authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Fuera el RLS intermedio de la Fase 1
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop policy "allow_all_authenticated" on producto_bases;
+drop policy "allow_all_authenticated" on producto_variantes;
+drop policy "allow_all_authenticated" on categoria_atributos;
+drop policy "allow_all_authenticated" on items_reposicion;
+drop policy "allow_all_authenticated" on listas_reposicion_historial;
+drop policy "allow_all_authenticated" on items_reposicion_historial;
+drop policy "allow_all_authenticated" on items_vencimiento;
+drop policy "allow_all_authenticated" on items_vencimiento_historial;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. Tablas de organización (§2.2)
+-- ─────────────────────────────────────────────────────────────────────────
+
+create policy "tiendas_select_miembros" on tiendas
+  for select to authenticated
+  using (id in (select mis_tiendas()));
+create policy "tiendas_update_admin" on tiendas
+  for update to authenticated
+  using (id in (select mis_tiendas_admin()))
+  with check (id in (select mis_tiendas_admin()));
+-- INSERT solo vía crear_tienda_con_admin (definer); DELETE fuera de scope.
+
+create policy "tienda_miembros_select_miembros" on tienda_miembros
+  for select to authenticated
+  using (tienda_id in (select mis_tiendas()));
+create policy "tienda_miembros_update_admin" on tienda_miembros
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas_admin()))
+  with check (tienda_id in (select mis_tiendas_admin()));
+create policy "tienda_miembros_delete_admin_o_propio" on tienda_miembros
+  for delete to authenticated
+  using (
+    tienda_id in (select mis_tiendas_admin())
+    or user_id = (select auth.uid())
+  );
+-- INSERT solo vía crear_tienda_con_admin / canjear_invitacion (definer).
+
+create policy "tienda_invitaciones_select_admin" on tienda_invitaciones
+  for select to authenticated
+  using (tienda_id in (select mis_tiendas_admin()));
+create policy "tienda_invitaciones_insert_admin" on tienda_invitaciones
+  for insert to authenticated
+  with check (tienda_id in (select mis_tiendas_admin()));
+create policy "tienda_invitaciones_update_admin" on tienda_invitaciones
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas_admin()))
+  with check (tienda_id in (select mis_tiendas_admin()));
+create policy "tienda_invitaciones_delete_admin" on tienda_invitaciones
+  for delete to authenticated
+  using (tienda_id in (select mis_tiendas_admin()));
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 4. Catálogo: miembros operan; borrar es de admin
+-- ─────────────────────────────────────────────────────────────────────────
+
+create policy "producto_bases_select_miembros" on producto_bases
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "producto_bases_insert_miembros" on producto_bases
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "producto_bases_update_miembros" on producto_bases
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas()))
+  with check (tienda_id in (select mis_tiendas()));
+create policy "producto_bases_delete_admin" on producto_bases
+  for delete to authenticated using (tienda_id in (select mis_tiendas_admin()));
+
+create policy "producto_variantes_select_miembros" on producto_variantes
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "producto_variantes_insert_miembros" on producto_variantes
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "producto_variantes_update_miembros" on producto_variantes
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas()))
+  with check (tienda_id in (select mis_tiendas()));
+create policy "producto_variantes_delete_admin" on producto_variantes
+  for delete to authenticated using (tienda_id in (select mis_tiendas_admin()));
+
+-- Definiciones de atributos: leer es de miembros, gestionarlas es de admin.
+create policy "categoria_atributos_select_miembros" on categoria_atributos
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "categoria_atributos_insert_admin" on categoria_atributos
+  for insert to authenticated with check (tienda_id in (select mis_tiendas_admin()));
+create policy "categoria_atributos_update_admin" on categoria_atributos
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas_admin()))
+  with check (tienda_id in (select mis_tiendas_admin()));
+create policy "categoria_atributos_delete_admin" on categoria_atributos
+  for delete to authenticated using (tienda_id in (select mis_tiendas_admin()));
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 5. Listas activas: operación plena de miembros
+-- ─────────────────────────────────────────────────────────────────────────
+
+create policy "items_reposicion_select_miembros" on items_reposicion
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_insert_miembros" on items_reposicion
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_update_miembros" on items_reposicion
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas()))
+  with check (tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_delete_miembros" on items_reposicion
+  for delete to authenticated using (tienda_id in (select mis_tiendas()));
+
+create policy "items_vencimiento_select_miembros" on items_vencimiento
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "items_vencimiento_insert_miembros" on items_vencimiento
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "items_vencimiento_update_miembros" on items_vencimiento
+  for update to authenticated
+  using (tienda_id in (select mis_tiendas()))
+  with check (tienda_id in (select mis_tiendas()));
+create policy "items_vencimiento_delete_miembros" on items_vencimiento
+  for delete to authenticated using (tienda_id in (select mis_tiendas()));
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 6. Historial: es el registro de auditoría del trabajo hecho — un
+--    empleado no puede borrar evidencia (delete solo admin) y nadie edita
+--    (sin policy de UPDATE). El INSERT de miembros lo necesitan las RPCs
+--    invoker de la 0015.
+-- ─────────────────────────────────────────────────────────────────────────
+
+create policy "listas_reposicion_historial_select_miembros" on listas_reposicion_historial
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "listas_reposicion_historial_insert_miembros" on listas_reposicion_historial
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "listas_reposicion_historial_delete_admin" on listas_reposicion_historial
+  for delete to authenticated using (tienda_id in (select mis_tiendas_admin()));
+
+create policy "items_reposicion_historial_select_miembros" on items_reposicion_historial
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_historial_insert_miembros" on items_reposicion_historial
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_historial_delete_admin" on items_reposicion_historial
+  for delete to authenticated using (tienda_id in (select mis_tiendas_admin()));
+
+create policy "items_vencimiento_historial_select_miembros" on items_vencimiento_historial
+  for select to authenticated using (tienda_id in (select mis_tiendas()));
+create policy "items_vencimiento_historial_insert_miembros" on items_vencimiento_historial
+  for insert to authenticated with check (tienda_id in (select mis_tiendas()));
+create policy "items_vencimiento_historial_delete_admin" on items_vencimiento_historial
+  for delete to authenticated using (tienda_id in (select mis_tiendas_admin()));

--- a/supabase/migrations/0015_rpcs_multitienda.sql
+++ b/supabase/migrations/0015_rpcs_multitienda.sql
@@ -1,0 +1,447 @@
+-- Fase 2 multi-tienda (3/3): las 5 RPCs pasan a SECURITY INVOKER (RLS como
+-- único punto de enforcement) y llegan las RPCs de tiendas/invitaciones
+-- (docs/SPECMULTIUSER.md §1.5). Regla para las DEFINER nuevas: cada guard
+-- que la policy ya no aplica va escrito DENTRO de la función, y cada una
+-- lleva su revoke a public/anon en esta misma migración.
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. agregar_item_reposicion → invoker. Firma y cuerpo sin cambios: como
+--    invoker, una variante ajena es invisible para el SELECT/UPDATE y el
+--    trigger de derivación (0013) completa tienda_id en el INSERT, validado
+--    por el WITH CHECK. El ON CONFLICT sigue apuntando al índice parcial.
+-- ─────────────────────────────────────────────────────────────────────────
+
+create or replace function agregar_item_reposicion(p_variante_id uuid, p_cantidad int)
+returns items_reposicion
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_item items_reposicion%rowtype;
+begin
+  update items_reposicion
+  set cantidad = cantidad + p_cantidad,
+      estado = 'pendiente'
+  where id = (
+    select id
+    from items_reposicion
+    where variante_id = p_variante_id
+    order by (estado = 'pendiente') desc, agregado_at desc
+    limit 1
+  )
+  returning * into v_item;
+
+  if found then
+    return v_item;
+  end if;
+
+  insert into items_reposicion (variante_id, cantidad, estado)
+  values (p_variante_id, p_cantidad, 'pendiente')
+  on conflict (variante_id) where estado = 'pendiente'
+  do update set cantidad = items_reposicion.cantidad + excluded.cantidad
+  returning * into v_item;
+
+  return v_item;
+end;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. guardar_lista_reposicion gana p_tienda_id (la tienda activa viene del
+--    cliente). El WHERE por tienda es IMPRESCINDIBLE, no redundante: como
+--    invoker, RLS filtra por TODAS las tiendas del usuario — sin el WHERE,
+--    un usuario con dos membresías que guarda la lista de A archivaría y
+--    vaciaría también los items pendientes de B.
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop function guardar_lista_reposicion();
+
+create function guardar_lista_reposicion(p_tienda_id uuid)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_lista_id uuid;
+  v_fecha_creacion timestamptz;
+  v_total_productos int;
+  v_total_repuestos int;
+  v_total_sin_stock int;
+  v_total_pendientes int;
+begin
+  if p_tienda_id not in (select mis_tiendas()) then
+    raise exception 'No sos miembro de esta tienda';
+  end if;
+
+  select
+    count(*),
+    count(*) filter (where estado = 'repuesto'),
+    count(*) filter (where estado = 'sin_stock'),
+    count(*) filter (where estado = 'pendiente'),
+    min(agregado_at)
+  into v_total_productos, v_total_repuestos, v_total_sin_stock, v_total_pendientes, v_fecha_creacion
+  from items_reposicion
+  where tienda_id = p_tienda_id;
+
+  if v_total_productos = 0 then
+    raise exception 'No hay items para guardar';
+  end if;
+
+  insert into listas_reposicion_historial (
+    tienda_id, fecha_creacion, total_productos, total_repuestos, total_sin_stock, total_pendientes
+  ) values (
+    p_tienda_id, v_fecha_creacion, v_total_productos, v_total_repuestos, v_total_sin_stock, v_total_pendientes
+  )
+  returning id into v_lista_id;
+
+  -- tienda_id del historial de items lo deriva el trigger desde lista_id.
+  insert into items_reposicion_historial (
+    lista_id, variante_id, producto_nombre, producto_marca, variante_nombre, cantidad, estado
+  )
+  select
+    v_lista_id,
+    ir.variante_id,
+    coalesce(pb.nombre, 'Producto sin nombre'),
+    pb.marca,
+    coalesce(pv.nombre_completo, 'Variante sin nombre'),
+    ir.cantidad,
+    ir.estado
+  from items_reposicion ir
+  left join producto_variantes pv on pv.id = ir.variante_id
+  left join producto_bases pb on pb.id = pv.producto_base_id
+  where ir.tienda_id = p_tienda_id;
+
+  -- Mantiene la regla "DELETE con WHERE" (migración 0005), ahora por tienda.
+  delete from items_reposicion where tienda_id = p_tienda_id;
+
+  return v_lista_id;
+end;
+$$;
+
+revoke execute on function guardar_lista_reposicion(uuid) from public, anon;
+grant execute on function guardar_lista_reposicion(uuid) to authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. retirar_item_vencimiento / retirar_items_vencimiento → invoker.
+--    Firmas y cuerpos sin cambios: con RLS, los ids ajenos "no existen"
+--    (la individual falla con 'no encontrado'; la masiva simplemente no
+--    los matchea). El historial deriva tienda_id por trigger.
+-- ─────────────────────────────────────────────────────────────────────────
+
+create or replace function retirar_item_vencimiento(p_item_id uuid)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_item items_vencimiento%rowtype;
+  v_producto_nombre text := 'Producto sin nombre';
+  v_producto_marca text := null;
+  v_variante_nombre text := 'Variante sin nombre';
+begin
+  select * into v_item from items_vencimiento where id = p_item_id;
+  if not found then
+    raise exception 'Item de vencimiento % no encontrado', p_item_id;
+  end if;
+
+  select coalesce(pb.nombre, v_producto_nombre), pb.marca, coalesce(pv.nombre_completo, v_variante_nombre)
+    into v_producto_nombre, v_producto_marca, v_variante_nombre
+  from producto_variantes pv
+  left join producto_bases pb on pb.id = pv.producto_base_id
+  where pv.id = v_item.variante_id;
+
+  insert into items_vencimiento_historial (
+    variante_id, producto_nombre, producto_marca, variante_nombre, cantidad, lote,
+    fecha_vencimiento, nivel_alerta_al_retirar
+  ) values (
+    v_item.variante_id, v_producto_nombre, v_producto_marca, v_variante_nombre, v_item.cantidad, v_item.lote,
+    v_item.fecha_vencimiento, calcular_nivel_alerta(v_item.fecha_vencimiento)
+  );
+
+  delete from items_vencimiento where id = p_item_id;
+end;
+$$;
+
+create or replace function retirar_items_vencimiento(p_item_ids uuid[])
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+begin
+  insert into items_vencimiento_historial (
+    variante_id, producto_nombre, producto_marca, variante_nombre, cantidad, lote,
+    fecha_vencimiento, nivel_alerta_al_retirar
+  )
+  select
+    iv.variante_id,
+    coalesce(pb.nombre, 'Producto sin nombre'),
+    pb.marca,
+    coalesce(pv.nombre_completo, 'Variante sin nombre'),
+    iv.cantidad,
+    iv.lote,
+    iv.fecha_vencimiento,
+    calcular_nivel_alerta(iv.fecha_vencimiento)
+  from items_vencimiento iv
+  left join producto_variantes pv on pv.id = iv.variante_id
+  left join producto_bases pb on pb.id = pv.producto_base_id
+  where iv.id = any(p_item_ids);
+
+  -- El proyecto rechaza DELETE sin WHERE (ver migración 0005); acá el
+  -- WHERE por ids ya lo cumple.
+  delete from items_vencimiento where id = any(p_item_ids);
+end;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 4. obtener_estadisticas_vencimiento gana p_tienda_id → invoker.
+--    Sin el filtro, un usuario multi-tienda vería agregados mezclados; sin
+--    invoker, CUALQUIER usuario veía los de todas las tiendas (hallazgo C1
+--    del análisis). Un no-miembro obtiene stats vacías (RLS filtra todo).
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop function obtener_estadisticas_vencimiento(timestamptz, timestamptz);
+
+create function obtener_estadisticas_vencimiento(
+  p_tienda_id uuid,
+  p_desde timestamptz,
+  p_hasta timestamptz
+)
+returns json
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with retirados as (
+    select
+      producto_nombre,
+      coalesce(cantidad, 1) as unidades,
+      (fecha_retiro::date - fecha_vencimiento) as dias_a_retiro
+    from items_vencimiento_historial
+    where tienda_id = p_tienda_id
+      and fecha_retiro >= p_desde
+      and fecha_retiro <= p_hasta
+  )
+  select json_build_object(
+    'total_retirados', coalesce((select sum(unidades) from retirados), 0)::int,
+    'promedio_dias_a_retiro', coalesce((select avg(dias_a_retiro) from retirados), 0),
+    'productos_mas_retirados', coalesce(
+      (
+        select json_agg(t)
+        from (
+          select producto_nombre, sum(unidades)::int as cantidad
+          from retirados
+          group by producto_nombre
+          order by cantidad desc
+          limit 10
+        ) t
+      ),
+      '[]'::json
+    )
+  );
+$$;
+
+revoke execute on function obtener_estadisticas_vencimiento(uuid, timestamptz, timestamptz) from public, anon;
+grant execute on function obtener_estadisticas_vencimiento(uuid, timestamptz, timestamptz) to authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 5. armar_nombre_completo gana p_tienda_id: sin el filtro, los nombres
+--    derivados mezclarían definiciones de atributos de otras tiendas.
+--    set_nombre_completo() le pasa new.tienda_id (ya seteado por el trigger
+--    de derivación de la 0013, que dispara antes por orden alfabético).
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop function armar_nombre_completo(text, text, jsonb);
+
+create function armar_nombre_completo(
+  p_tienda_id uuid,
+  p_nombre_base text,
+  p_categoria text,
+  p_atributos jsonb
+)
+returns text
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with defs as (
+    select clave, orden from categoria_atributos
+    where tienda_id = p_tienda_id and categoria = p_categoria
+    union all
+    select clave, orden from categoria_atributos
+    where tienda_id = p_tienda_id
+      and categoria is null
+      and not exists (
+        select 1 from categoria_atributos
+        where tienda_id = p_tienda_id and categoria = p_categoria
+      )
+  )
+  select trim(concat_ws(' ',
+    p_nombre_base,
+    case when jsonb_typeof(p_atributos) = 'object' then (
+      select string_agg(a.valor, ' ' order by coalesce(d.orden, 999), a.clave)
+      from jsonb_each_text(p_atributos) as a(clave, valor)
+      left join defs d on d.clave = a.clave
+      where nullif(trim(a.valor), '') is not null
+    ) end
+  ))
+$$;
+
+create or replace function set_nombre_completo()
+returns trigger as $$
+declare
+  v_nombre text;
+  v_categoria text;
+begin
+  if tg_op = 'INSERT'
+     and new.atributos = '{}'::jsonb
+     and new.nombre_completo is not null then
+    return new;
+  end if;
+  select nombre, categoria into v_nombre, v_categoria
+  from producto_bases where id = new.producto_base_id;
+  new.nombre_completo = armar_nombre_completo(new.tienda_id, v_nombre, v_categoria, new.atributos);
+  return new;
+end;
+$$ language plpgsql set search_path = public;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 6. RPCs de tiendas e invitaciones (SECURITY DEFINER: resuelven el
+--    huevo-y-gallina de RLS — sin membresía no podés insertar membresías).
+-- ─────────────────────────────────────────────────────────────────────────
+
+create function crear_tienda_con_admin(p_nombre text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_tienda_id uuid;
+begin
+  if v_uid is null then
+    raise exception 'Requiere sesión';
+  end if;
+
+  insert into tiendas (nombre, created_by) values (p_nombre, v_uid)
+  returning id into v_tienda_id;
+
+  insert into tienda_miembros (tienda_id, user_id, rol)
+  values (v_tienda_id, v_uid, 'admin');
+
+  -- Seed de definiciones default, como el de la migración 0008.
+  insert into categoria_atributos (tienda_id, categoria, clave, etiqueta, orden) values
+    (v_tienda_id, null, 'tipo',   'Tipo',   0),
+    (v_tienda_id, null, 'sabor',  'Sabor',  1),
+    (v_tienda_id, null, 'tamano', 'Tamaño', 2);
+
+  return v_tienda_id;
+end;
+$$;
+
+-- Canje ATÓMICO (sin race check-then-increment: el UPDATE toma el row lock
+-- y el segundo canje concurrente ya no matchea usos < max_usos). Un
+-- re-canje de alguien que ya es miembro no quema usos.
+create function canjear_invitacion(p_codigo text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_tienda_id uuid;
+  v_rol text;
+begin
+  if v_uid is null then
+    raise exception 'Requiere sesión';
+  end if;
+
+  select tienda_id into v_tienda_id from tienda_invitaciones where codigo = p_codigo;
+  if v_tienda_id is not null and exists (
+    select 1 from tienda_miembros
+    where tienda_id = v_tienda_id and user_id = v_uid
+  ) then
+    return v_tienda_id;
+  end if;
+
+  update tienda_invitaciones
+     set usos = usos + 1
+   where codigo = p_codigo
+     and not revocada
+     and expira_at > now()
+     and usos < max_usos
+  returning tienda_id, rol into v_tienda_id, v_rol;
+
+  if v_tienda_id is null then
+    raise exception 'Código inválido, vencido o agotado';
+  end if;
+
+  insert into tienda_miembros (tienda_id, user_id, rol)
+  values (v_tienda_id, v_uid, v_rol)
+  on conflict do nothing;
+
+  return v_tienda_id;
+end;
+$$;
+
+-- Guard admin en la primera línea: como DEFINER bypasea la policy de
+-- insert de tienda_invitaciones — sin este check, cualquier autenticado
+-- emitiría invitaciones (incluso de admin) de cualquier tienda.
+create function generar_codigo_invitacion(
+  p_tienda_id uuid,
+  p_rol text default 'empleado',
+  p_max_usos int default 1,
+  p_dias int default 7
+)
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  -- Sin caracteres ambiguos (0/O, 1/I/L): el caso de uso es dictarlo en voz
+  -- alta en el pasillo.
+  v_alfabeto constant text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  v_codigo text;
+begin
+  if p_tienda_id not in (select mis_tiendas_admin()) then
+    raise exception 'Solo un admin de la tienda puede generar invitaciones';
+  end if;
+  if p_rol not in ('admin', 'empleado') then
+    raise exception 'Rol inválido: %', p_rol;
+  end if;
+  if p_max_usos < 1 or p_dias < 1 then
+    raise exception 'max_usos y dias deben ser positivos';
+  end if;
+
+  loop
+    select string_agg(
+      substr(v_alfabeto, (get_byte(gen_random_bytes(1), 0) % length(v_alfabeto)) + 1, 1),
+      ''
+    )
+    from generate_series(1, 8)
+    into v_codigo;
+
+    begin
+      insert into tienda_invitaciones (tienda_id, codigo, rol, creado_por, expira_at, max_usos)
+      values (p_tienda_id, v_codigo, p_rol, auth.uid(), now() + make_interval(days => p_dias), p_max_usos);
+      return v_codigo;
+    exception when unique_violation then
+      -- Colisión de código (improbable con 31^8): reintentar.
+    end;
+  end loop;
+end;
+$$;
+
+revoke execute on function crear_tienda_con_admin(text) from public, anon;
+revoke execute on function canjear_invitacion(text) from public, anon;
+revoke execute on function generar_codigo_invitacion(uuid, text, int, int) from public, anon;
+grant execute on function crear_tienda_con_admin(text) to authenticated, service_role;
+grant execute on function canjear_invitacion(text) to authenticated, service_role;
+grant execute on function generar_codigo_invitacion(uuid, text, int, int) to authenticated, service_role;

--- a/supabase/migrations/0015_rpcs_multitienda.sql
+++ b/supabase/migrations/0015_rpcs_multitienda.sql
@@ -402,7 +402,10 @@ create function generar_codigo_invitacion(
 returns text
 language plpgsql
 security definer
-set search_path = public
+-- extensions en el search_path: gen_random_bytes (pgcrypto) vive en el
+-- schema extensions en Supabase; un schema inexistente se ignora, así que
+-- también funciona donde pgcrypto quedó en public.
+set search_path = public, extensions
 as $$
 declare
   -- Sin caracteres ambiguos (0/O, 1/I/L): el caso de uso es dictarlo en voz


### PR DESCRIPTION
## 📝 Descripción

Fase 2 del roadmap de `docs/SPECMULTIUSER.md` — el scoping real por tienda, la fase más delicada del proyecto.

**Base de datos** (migraciones `0013`–`0015`, ⚠️ **NO se aplican con este merge** — ver Notas):
- **`0013_constraints_por_tienda.sql`**: triggers `BEFORE INSERT` de derivación **incondicional** de `tienda_id` (ignoran cualquier valor del cliente — la tienda de un item ES la de su variante; cierra el hueco de consistencia A1 del análisis), unicidad por tienda (EAN, bases nombre+marca, atributos), índices compuestos de hot paths y drop de los `DEFAULT` de la Fase 1. El índice parcial de pendientes no se toca (es el target del `ON CONFLICT`).
- **`0014_rls_por_tienda.sql`**: helpers `mis_tiendas()`/`mis_tiendas_admin()` (InitPlan, sin recursión) y policies por membresía en las 11 tablas — historial con `DELETE` solo admin y sin `UPDATE`; `tiendas`/`tienda_miembros` con inserts solo vía RPC definer.
- **`0015_rpcs_multitienda.sql`**: las **5** RPCs a `SECURITY INVOKER`. `guardar_lista_reposicion(p_tienda_id)` y `obtener_estadisticas_vencimiento(p_tienda_id, ...)` cambian de firma — el `WHERE tienda_id` es **correctness** para usuarios multi-membresía (RLS filtra por *todas* mis tiendas). `armar_nombre_completo` tienda-aware. Nuevas: `crear_tienda_con_admin` (seed incluido), `canjear_invitacion` (canje **atómico** vía `UPDATE...RETURNING`, re-canje idempotente sin quemar usos) y `generar_codigo_invitacion` (guard admin en la primera línea; alfabeto sin caracteres ambiguos). Todas con `REVOKE`/`GRANT` explícitos.

**Cliente**:
- `AuthProvider` expone `tiendaActiva`/`rol` (membresía consultada online; `useSesionStore` persistido para arranque offline); `QueryProvider` con buster `v4:${userId}:${tiendaId}` y remonte del QueryClient al cambiar la identidad.
- Query keys `["tienda", tiendaId, ...]` vía factories (`src/lib/queryKeys.ts`); hooks con `enabled: !!tiendaActiva`; los servicios de reposición/vencimiento/catálogo filtran por la tienda activa; el lookup de EAN es por tienda (el mismo código puede existir en dos tiendas).
- Estadísticas de vencimiento pasan `p_tienda_id` y pierden el fallback client-side.
- Outbox: cola por usuario (`queue:${userId}`), `getSession()` antes de procesar, y el remap de tempIds ahora se **persiste en la cola** (cierra el edge case M4 del análisis: creación y updates dependientes en corridas distintas).
- Recientes y registro de vencimientos notificados por tienda; rate limit del proxy por usuario (sub del JWT sin verificar, solo como clave); `crear-manual`/`parsear` reciben `tiendaId` y lo validan.

**Tests**:
- **Suite de aislamiento RLS** (`src/tests/integration/aislamiento-rls.test.ts`) — el gate de la fase: 2 usuarios × 2 tiendas por tabla × operación, las 5 RPCs con ids ajenos, invitaciones (revocada/agotada/re-canje idempotente), el caso **multi-membresía** de `guardar_lista_reposicion`, y el mismo EAN creable en dos tiendas.

## 🎯 Tipo de cambio

- [x] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [x] 💥 Breaking change (cambio que rompe compatibilidad)

## 🔗 Issue relacionado

Roadmap de `docs/SPECMULTIUSER.md` (Fase 2).

## 🧪 Testing

- [x] 169 tests de unidad verdes (los afectados por firmas nuevas, actualizados)
- [x] `tsc --noEmit` limpio
- [x] `npm run lint` sin errores nuevos (las 10 warnings son preexistentes)
- [x] `next build` OK
- [ ] **Suite de aislamiento RLS contra stack local** (`supabase start` + `supabase db reset` + `npm run test:integration`) — requiere Docker; es el gate antes del deploy
- [ ] Funciona offline (PWA) — verificación manual post-deploy

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado el código en áreas difíciles de entender
- [x] Mis cambios no generan warnings nuevos
- [x] He actualizado la documentación correspondiente
- [x] Los tests existentes pasan correctamente

## 🎯 Instrucciones de testing

1. **Gate de la fase (local, con Docker)**: `supabase start` → `supabase db reset` (aplica 0001–0015) → exportar keys de `supabase status` → `npm run test:integration` → la suite de aislamiento debe estar verde.
2. Deploy coordinado (como la Fase 1, pero **migraciones + deploy juntos**): la firma nueva de `guardar_lista_reposicion(p_tienda_id)` es incompatible cruzada — código viejo contra base migrada (o al revés) rompe "guardar lista" y "estadísticas de vencimiento" hasta que ambos estén del mismo lado. Ventana corta con la tienda tranquila.
3. Post-deploy: operar la app logueado (listas, escanear, crear producto, guardar lista, estadísticas), verificar arranque offline, y correr `get_advisors`.

## 📌 Notas adicionales

- ⚠️ **Este merge NO aplica las migraciones**: como en la Fase 1, se aplican en el deploy coordinado. A diferencia de la Fase 1, acá migraciones y deploy deben ir **juntos** (firmas de RPC incompatibles cruzadas).
- Deviación menor de la spec: en vez de guardar `userId` dentro de cada operación del outbox y "saltear las ajenas", la cola es por usuario (`queue:${userId}`) — el mismo aislamiento por diseño, sin estados intermedios.
- El fix del remap de tempIds (M4) se pagó acá (6 líneas) en vez de documentarlo como edge case: tocar el mismo archivo lo dejaba gratis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW)_