### PR TITLE
Fase 3 multi-tienda: invitaciones, roles y gestión de equipo

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,14 +6,18 @@ import {
   claseInput,
   MensajeError,
 } from "@/components/auth/AuthCard";
+import { destinoSeguro } from "@/lib/navegacion";
 import { supabase } from "@/lib/supabase";
 import { Loader2 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { FormEvent, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, Suspense, useState } from "react";
 
-export default function LoginPage() {
+function LoginContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Adónde volver post-login (p. ej. /unirse?codigo=X), saneado.
+  const next = destinoSeguro(searchParams.get("next"));
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -36,7 +40,7 @@ export default function LoginPage() {
       );
       return;
     }
-    router.replace("/");
+    router.replace(next);
   }
 
   return (
@@ -73,10 +77,31 @@ export default function LoginPage() {
         <Link href="/recuperar" className="text-accent">
           Olvidé mi contraseña
         </Link>
-        <Link href="/registro" className="text-fg-secondary">
+        <Link
+          href={
+            next === "/"
+              ? "/registro"
+              : `/registro?next=${encodeURIComponent(next)}`
+          }
+          className="text-fg-secondary"
+        >
           ¿No tenés cuenta? <span className="text-accent">Registrate</span>
         </Link>
       </div>
     </AuthCard>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-dvh bg-canvas flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-accent" />
+        </div>
+      }
+    >
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import {
+  AuthCard,
+  claseBotonPrimario,
+  claseInput,
+  MensajeError,
+} from "@/components/auth/AuthCard";
+import { useAuth } from "@/components/AuthProvider";
+import { useCerrarSesion } from "@/hooks/useCerrarSesion";
+import { canjearInvitacion, crearTienda } from "@/services/equipo";
+import { Loader2, Store, Ticket } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+
+type Modo = "elegir" | "crear" | "codigo";
+
+/**
+ * Onboarding post-registro (Fase 3): una cuenta sin membresía no ve ningún
+ * dato (RLS) — acá elige entre fundar su tienda o canjear el código que le
+ * pasó un encargado. AuthProvider redirige a esta pantalla cuando detecta
+ * sinTienda; al completar cualquiera de los dos caminos, refrescarMembresia
+ * resuelve la tienda nueva y se vuelve a la app.
+ */
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { user, cargando, tiendaActiva, sinTienda, refrescarMembresia } =
+    useAuth();
+  const { cerrarSesion, cerrando } = useCerrarSesion();
+  const [modo, setModo] = useState<Modo>("elegir");
+  const [nombre, setNombre] = useState("");
+  const [codigo, setCodigo] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+
+  // Con membresía esta pantalla no aplica (llegada por URL directa).
+  useEffect(() => {
+    if (!cargando && user && tiendaActiva && !sinTienda) {
+      router.replace("/");
+    }
+  }, [cargando, user, tiendaActiva, sinTienda, router]);
+
+  async function onCrear(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setEnviando(true);
+    try {
+      await crearTienda(nombre);
+      await refrescarMembresia();
+      router.replace("/");
+    } catch (err) {
+      setEnviando(false);
+      setError(
+        err instanceof Error ? err.message : "No se pudo crear la tienda"
+      );
+    }
+  }
+
+  async function onCanjear(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setEnviando(true);
+    try {
+      await canjearInvitacion(codigo);
+      await refrescarMembresia();
+      router.replace("/");
+    } catch (err) {
+      setEnviando(false);
+      setError(
+        err instanceof Error && /inválido|vencido|agotado/i.test(err.message)
+          ? "Código inválido, vencido o agotado"
+          : "No se pudo canjear el código. Probá de nuevo."
+      );
+    }
+  }
+
+  if (cargando) {
+    return (
+      <div className="min-h-dvh bg-canvas flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-accent" />
+      </div>
+    );
+  }
+
+  return (
+    <AuthCard
+      titulo="¡Ya casi!"
+      subtitulo="Tu cuenta necesita una tienda para empezar"
+    >
+      {modo === "elegir" && (
+        <div className="space-y-3">
+          <button
+            onClick={() => {
+              setError(null);
+              setModo("crear");
+            }}
+            className="w-full p-4 rounded-2xl bg-surface-2 text-left flex items-center gap-3 hover:ring-2 hover:ring-accent transition-shadow"
+          >
+            <Store className="w-6 h-6 text-accent shrink-0" />
+            <span>
+              <span className="block font-semibold text-fg">
+                Crear mi tienda
+              </span>
+              <span className="block text-sm text-fg-secondary">
+                Arrancás de cero como encargado
+              </span>
+            </span>
+          </button>
+          <button
+            onClick={() => {
+              setError(null);
+              setModo("codigo");
+            }}
+            className="w-full p-4 rounded-2xl bg-surface-2 text-left flex items-center gap-3 hover:ring-2 hover:ring-accent transition-shadow"
+          >
+            <Ticket className="w-6 h-6 text-accent shrink-0" />
+            <span>
+              <span className="block font-semibold text-fg">
+                Tengo un código
+              </span>
+              <span className="block text-sm text-fg-secondary">
+                Te invitaron a una tienda existente
+              </span>
+            </span>
+          </button>
+        </div>
+      )}
+
+      {modo === "crear" && (
+        <form onSubmit={onCrear} className="space-y-3">
+          <input
+            type="text"
+            required
+            maxLength={80}
+            placeholder="Nombre de la tienda"
+            value={nombre}
+            onChange={(e) => setNombre(e.target.value)}
+            className={claseInput}
+            autoFocus
+          />
+          <MensajeError mensaje={error} />
+          <button
+            type="submit"
+            disabled={enviando || nombre.trim().length === 0}
+            className={claseBotonPrimario}
+          >
+            {enviando ? (
+              <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+            ) : (
+              "Crear tienda"
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setModo("elegir")}
+            className="w-full text-sm text-fg-secondary"
+          >
+            Volver
+          </button>
+        </form>
+      )}
+
+      {modo === "codigo" && (
+        <form onSubmit={onCanjear} className="space-y-3">
+          <input
+            type="text"
+            required
+            maxLength={8}
+            placeholder="Código de invitación"
+            value={codigo}
+            onChange={(e) => setCodigo(e.target.value.toUpperCase())}
+            className={`${claseInput} uppercase tracking-widest text-center font-mono`}
+            autoFocus
+          />
+          <MensajeError mensaje={error} />
+          <button
+            type="submit"
+            disabled={enviando || codigo.trim().length === 0}
+            className={claseBotonPrimario}
+          >
+            {enviando ? (
+              <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+            ) : (
+              "Unirme a la tienda"
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setModo("elegir")}
+            className="w-full text-sm text-fg-secondary"
+          >
+            Volver
+          </button>
+        </form>
+      )}
+
+      <div className="mt-6 text-center">
+        <button
+          onClick={cerrarSesion}
+          disabled={cerrando}
+          className="text-sm text-fg-tertiary underline-offset-2 hover:underline"
+        >
+          {user?.email ? `Salir de ${user.email}` : "Cerrar sesión"}
+        </button>
+      </div>
+    </AuthCard>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ import { useNotificacionesVencimiento } from "@/hooks/useNotificacionesVencimien
 import { springGentle } from "@/lib/motion";
 import { ActiveView, useUiStore } from "@/store/ui";
 import { AnimatePresence, motion as m } from "framer-motion";
-import { History, Loader2, Search } from "lucide-react";
+import { History, Loader2, Search, Store } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
@@ -97,6 +97,13 @@ function HomePageContent() {
                   className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors"
                 >
                   <History size={22} />
+                </Link>
+                <Link
+                  href="/tienda"
+                  aria-label="Mi tienda y equipo"
+                  className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors"
+                >
+                  <Store size={22} />
                 </Link>
                 <OutboxBadge />
                 <ThemeToggle />

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -6,14 +6,19 @@ import {
   claseInput,
   MensajeError,
 } from "@/components/auth/AuthCard";
+import { destinoSeguro } from "@/lib/navegacion";
 import { supabase } from "@/lib/supabase";
 import { Loader2 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { FormEvent, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, Suspense, useState } from "react";
 
-export default function RegistroPage() {
+function RegistroContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Adónde seguir post-registro: /unirse?codigo=X cuando viene de una
+  // invitación; sin next, AuthProvider manda la cuenta nueva a /onboarding.
+  const next = destinoSeguro(searchParams.get("next"));
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -30,8 +35,6 @@ export default function RegistroPage() {
     });
     setEnviando(false);
     if (signUpError) {
-      // Durante las Fases 1–2 los signups públicos están deshabilitados en
-      // Supabase Auth; se habilitan con el onboarding de la Fase 3.
       setError(
         /signup.*(disabled|not allowed)/i.test(signUpError.message)
           ? "El registro está deshabilitado por ahora. Pedile acceso al encargado."
@@ -40,7 +43,7 @@ export default function RegistroPage() {
       return;
     }
     if (data.session) {
-      router.replace("/");
+      router.replace(next);
       return;
     }
     setPendienteConfirmacion(true);
@@ -95,10 +98,29 @@ export default function RegistroPage() {
         </button>
       </form>
       <div className="mt-4 text-center text-sm">
-        <Link href="/login" className="text-fg-secondary">
+        <Link
+          href={
+            next === "/" ? "/login" : `/login?next=${encodeURIComponent(next)}`
+          }
+          className="text-fg-secondary"
+        >
           ¿Ya tenés cuenta? <span className="text-accent">Iniciá sesión</span>
         </Link>
       </div>
     </AuthCard>
+  );
+}
+
+export default function RegistroPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-dvh bg-canvas flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-accent" />
+        </div>
+      }
+    >
+      <RegistroContent />
+    </Suspense>
   );
 }

--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -1,0 +1,526 @@
+"use client";
+
+import { useAuth } from "@/components/AuthProvider";
+import { AppShell } from "@/components/shell/AppShell";
+import { PageHeader } from "@/components/shell/PageHeader";
+import { BottomSheet } from "@/components/ui/BottomSheet";
+import {
+  useCambiarRol,
+  useGenerarInvitacion,
+  useInvitaciones,
+  useMiembros,
+  useNombreTienda,
+  useQuitarMiembro,
+  useRenombrarTienda,
+  useRevocarInvitacion,
+} from "@/hooks/useEquipo";
+import type { MiembroTienda } from "@/services/equipo";
+import type { RolTienda } from "@/store/sesion";
+import {
+  Check,
+  Copy,
+  Loader2,
+  LogOut,
+  Pencil,
+  Plus,
+  ShieldCheck,
+  Ticket,
+  UserMinus,
+  X,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import toast from "react-hot-toast";
+
+const MENSAJE_ULTIMO_ADMIN = "La tienda no puede quedarse sin admin";
+
+function mensajeDeError(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message.includes(MENSAJE_ULTIMO_ADMIN)) {
+    return `${MENSAJE_ULTIMO_ADMIN}: nombrá otro admin primero`;
+  }
+  return fallback;
+}
+
+/** Nombre de la tienda, editable inline por el admin. */
+function SeccionNombre({ esAdmin }: { esAdmin: boolean }) {
+  const { data: nombre, isPending } = useNombreTienda();
+  const renombrar = useRenombrarTienda();
+  const [editando, setEditando] = useState(false);
+  const [borrador, setBorrador] = useState("");
+
+  const guardar = async () => {
+    const limpio = borrador.trim();
+    if (!limpio || limpio === nombre) {
+      setEditando(false);
+      return;
+    }
+    try {
+      await renombrar.mutateAsync(limpio);
+      toast.success("Tienda renombrada");
+      setEditando(false);
+    } catch {
+      toast.error("No se pudo renombrar la tienda");
+    }
+  };
+
+  return (
+    <div className="island p-4 mb-4">
+      <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide mb-2">
+        Tienda
+      </div>
+      {editando ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            maxLength={80}
+            value={borrador}
+            onChange={(e) => setBorrador(e.target.value)}
+            className="flex-1 h-11 px-3 rounded-field bg-surface-2 text-fg outline-none focus:ring-2 focus:ring-accent"
+            autoFocus
+          />
+          <button
+            onClick={guardar}
+            disabled={renombrar.isPending}
+            aria-label="Guardar nombre"
+            className="w-11 h-11 flex items-center justify-center rounded-full bg-accent text-on-accent disabled:opacity-50"
+          >
+            {renombrar.isPending ? (
+              <Loader2 size={18} className="animate-spin" />
+            ) : (
+              <Check size={18} />
+            )}
+          </button>
+          <button
+            onClick={() => setEditando(false)}
+            aria-label="Cancelar"
+            className="w-11 h-11 flex items-center justify-center rounded-full bg-surface-2 text-fg-secondary"
+          >
+            <X size={18} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-title-3 text-fg font-semibold truncate">
+            {isPending ? "…" : nombre}
+          </span>
+          {esAdmin && (
+            <button
+              onClick={() => {
+                setBorrador(nombre ?? "");
+                setEditando(true);
+              }}
+              aria-label="Renombrar tienda"
+              className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors shrink-0"
+            >
+              <Pencil size={18} />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChipRol({ rol }: { rol: RolTienda }) {
+  return rol === "admin" ? (
+    <span className="inline-flex items-center gap-1 bg-accent-soft text-accent px-2.5 py-1 rounded-chip text-caption font-semibold">
+      <ShieldCheck size={12} /> Admin
+    </span>
+  ) : (
+    <span className="bg-surface-2 text-fg-secondary px-2.5 py-1 rounded-chip text-caption font-semibold">
+      Empleado
+    </span>
+  );
+}
+
+/** Lista de miembros; el admin puede cambiar roles y expulsar. */
+function SeccionEquipo({ esAdmin }: { esAdmin: boolean }) {
+  const { user } = useAuth();
+  const { data: miembros, isPending, isError } = useMiembros();
+  const cambiarRol = useCambiarRol();
+  const quitar = useQuitarMiembro();
+  const [aExpulsar, setAExpulsar] = useState<MiembroTienda | null>(null);
+
+  const onCambiarRol = async (m: MiembroTienda) => {
+    const nuevo: RolTienda = m.rol === "admin" ? "empleado" : "admin";
+    try {
+      await cambiarRol.mutateAsync({ userId: m.userId, rol: nuevo });
+      toast.success(
+        nuevo === "admin" ? `${m.email} ahora es admin` : `${m.email} ahora es empleado`
+      );
+    } catch (err) {
+      toast.error(mensajeDeError(err, "No se pudo cambiar el rol"));
+    }
+  };
+
+  const onExpulsar = async () => {
+    if (!aExpulsar) return;
+    try {
+      await quitar.mutateAsync(aExpulsar.userId);
+      toast.success(`${aExpulsar.email} fue quitado de la tienda`);
+      setAExpulsar(null);
+    } catch (err) {
+      toast.error(mensajeDeError(err, "No se pudo quitar al miembro"));
+    }
+  };
+
+  return (
+    <div className="island p-4 mb-4">
+      <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide mb-3">
+        Equipo
+      </div>
+      {isPending && (
+        <div className="py-4 flex justify-center">
+          <Loader2 className="w-5 h-5 animate-spin text-fg-tertiary" />
+        </div>
+      )}
+      {isError && (
+        <p className="text-subhead text-fg-secondary py-2">
+          No se pudo cargar el equipo. Revisá tu conexión.
+        </p>
+      )}
+      <div className="space-y-3">
+        {miembros?.map((m) => {
+          const esYo = m.userId === user?.id;
+          return (
+            <div key={m.userId} className="flex items-center gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="text-body text-fg truncate">
+                  {m.email}
+                  {esYo && (
+                    <span className="text-fg-tertiary text-footnote ml-1.5">
+                      (vos)
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1">
+                  <ChipRol rol={m.rol} />
+                </div>
+              </div>
+              {esAdmin && !esYo && (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    onClick={() => onCambiarRol(m)}
+                    disabled={cambiarRol.isPending}
+                    className="h-9 px-3 rounded-full bg-surface-2 text-fg-secondary text-caption font-semibold hover:bg-border transition-colors disabled:opacity-50"
+                  >
+                    {m.rol === "admin" ? "Hacer empleado" : "Hacer admin"}
+                  </button>
+                  <button
+                    onClick={() => setAExpulsar(m)}
+                    aria-label={`Quitar a ${m.email}`}
+                    className="w-9 h-9 flex items-center justify-center rounded-full text-alert-critico hover:bg-alert-critico/10 transition-colors"
+                  >
+                    <UserMinus size={18} />
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <BottomSheet
+        isOpen={!!aExpulsar}
+        onClose={() => setAExpulsar(null)}
+        title="Quitar de la tienda"
+      >
+        <div className="space-y-4">
+          <p className="text-body text-fg-secondary">
+            {aExpulsar?.email} va a perder el acceso a los datos de la tienda
+            en cuanto vuelva a conectarse. ¿Continuar?
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setAExpulsar(null)}
+              disabled={quitar.isPending}
+              className="flex-1 bg-surface-2 hover:bg-border text-fg-secondary font-semibold h-12 px-4 rounded-field transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={onExpulsar}
+              disabled={quitar.isPending}
+              className="flex-1 bg-alert-critico text-white font-semibold h-12 px-4 rounded-field transition-colors disabled:opacity-50"
+            >
+              {quitar.isPending ? "Quitando..." : "Quitar"}
+            </button>
+          </div>
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}
+
+/** Invitaciones (solo admin): generar códigos y revocar los vigentes. */
+function SeccionInvitaciones() {
+  const { data: invitaciones } = useInvitaciones();
+  const generar = useGenerarInvitacion();
+  const revocar = useRevocarInvitacionConToast();
+  const [sheetAbierto, setSheetAbierto] = useState(false);
+  const [rolNuevo, setRolNuevo] = useState<RolTienda>("empleado");
+  const [usosNuevos, setUsosNuevos] = useState(1);
+  const [codigoGenerado, setCodigoGenerado] = useState<string | null>(null);
+
+  const vigentes = (invitaciones ?? []).filter(
+    (i) => !i.revocada && i.expiraAt > new Date() && i.usos < i.maxUsos
+  );
+
+  const onGenerar = async () => {
+    try {
+      const codigo = await generar.mutateAsync({
+        rol: rolNuevo,
+        maxUsos: usosNuevos,
+        dias: 7,
+      });
+      setCodigoGenerado(codigo);
+    } catch {
+      toast.error("No se pudo generar el código");
+    }
+  };
+
+  const copiarLink = (codigo: string) => {
+    navigator.clipboard
+      .writeText(`${window.location.origin}/unirse?codigo=${codigo}`)
+      .then(() => toast.success("Link copiado"))
+      .catch(() => toast.error("No se pudo copiar"));
+  };
+
+  const cerrarSheet = () => {
+    setSheetAbierto(false);
+    setCodigoGenerado(null);
+  };
+
+  return (
+    <div className="island p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide">
+          Invitaciones
+        </div>
+        <button
+          onClick={() => setSheetAbierto(true)}
+          className="h-9 px-3 rounded-full bg-accent text-on-accent text-caption font-semibold flex items-center gap-1.5"
+        >
+          <Plus size={14} /> Generar código
+        </button>
+      </div>
+
+      {vigentes.length === 0 ? (
+        <p className="text-subhead text-fg-secondary flex items-center gap-2">
+          <Ticket size={16} className="text-fg-tertiary" />
+          No hay códigos vigentes
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {vigentes.map((inv) => (
+            <div key={inv.id} className="flex items-center gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="font-mono text-body tracking-widest text-fg">
+                  {inv.codigo}
+                </div>
+                <div className="text-footnote text-fg-tertiary mt-0.5">
+                  {inv.rol === "admin" ? "Admin" : "Empleado"} · {inv.usos}/
+                  {inv.maxUsos} usos · vence{" "}
+                  {new Intl.DateTimeFormat("es-ES", {
+                    day: "numeric",
+                    month: "short",
+                  }).format(inv.expiraAt)}
+                </div>
+              </div>
+              <button
+                onClick={() => copiarLink(inv.codigo)}
+                aria-label="Copiar link de invitación"
+                className="w-9 h-9 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors"
+              >
+                <Copy size={16} />
+              </button>
+              <button
+                onClick={() => revocar(inv.id)}
+                aria-label="Revocar invitación"
+                className="w-9 h-9 flex items-center justify-center rounded-full text-alert-critico hover:bg-alert-critico/10 transition-colors"
+              >
+                <X size={18} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <BottomSheet
+        isOpen={sheetAbierto}
+        onClose={cerrarSheet}
+        title={codigoGenerado ? "Código listo" : "Generar invitación"}
+      >
+        {codigoGenerado ? (
+          <div className="space-y-4 text-center">
+            <p className="text-body text-fg-secondary">
+              Dictalo en voz alta o compartí el link. Vence en 7 días.
+            </p>
+            <div className="font-mono text-3xl tracking-[0.3em] text-fg py-2">
+              {codigoGenerado}
+            </div>
+            <button
+              onClick={() => copiarLink(codigoGenerado)}
+              className="w-full h-12 rounded-full bg-accent text-on-accent font-semibold flex items-center justify-center gap-2"
+            >
+              <Copy size={18} /> Copiar link
+            </button>
+            <button
+              onClick={cerrarSheet}
+              className="w-full h-12 rounded-full bg-surface-2 text-fg-secondary font-semibold"
+            >
+              Listo
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide mb-2">
+                Rol del invitado
+              </div>
+              <div className="flex gap-2">
+                {(["empleado", "admin"] as const).map((r) => (
+                  <button
+                    key={r}
+                    onClick={() => setRolNuevo(r)}
+                    className={`flex-1 h-11 rounded-field font-semibold text-subhead transition-colors ${
+                      rolNuevo === r
+                        ? "bg-accent text-on-accent"
+                        : "bg-surface-2 text-fg-secondary"
+                    }`}
+                  >
+                    {r === "empleado" ? "Empleado" : "Admin"}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide mb-2">
+                Cantidad de usos
+              </div>
+              <div className="flex gap-2">
+                {[1, 5, 10].map((n) => (
+                  <button
+                    key={n}
+                    onClick={() => setUsosNuevos(n)}
+                    className={`flex-1 h-11 rounded-field font-semibold text-subhead transition-colors ${
+                      usosNuevos === n
+                        ? "bg-accent text-on-accent"
+                        : "bg-surface-2 text-fg-secondary"
+                    }`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <button
+              onClick={onGenerar}
+              disabled={generar.isPending}
+              className="w-full h-12 rounded-full bg-accent text-on-accent font-semibold disabled:opacity-50"
+            >
+              {generar.isPending ? (
+                <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+              ) : (
+                "Generar código"
+              )}
+            </button>
+          </div>
+        )}
+      </BottomSheet>
+    </div>
+  );
+}
+
+/** Wrapper chico para no repetir el manejo de errores del revoke. */
+function useRevocarInvitacionConToast() {
+  const revocar = useRevocarInvitacion();
+  return async (id: string) => {
+    try {
+      await revocar.mutateAsync(id);
+      toast.success("Invitación revocada");
+    } catch {
+      toast.error("No se pudo revocar la invitación");
+    }
+  };
+}
+
+function SeccionSalir() {
+  const router = useRouter();
+  const { user, refrescarMembresia } = useAuth();
+  const quitar = useQuitarMiembro();
+  const [confirmando, setConfirmando] = useState(false);
+
+  const onSalir = async () => {
+    if (!user) return;
+    try {
+      await quitar.mutateAsync(user.id);
+      await refrescarMembresia();
+      router.replace("/onboarding");
+    } catch (err) {
+      toast.error(mensajeDeError(err, "No se pudo salir de la tienda"));
+      setConfirmando(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setConfirmando(true)}
+        className="w-full h-12 bg-alert-critico/10 hover:bg-alert-critico/20 text-alert-critico font-semibold rounded-field transition-colors flex items-center justify-center gap-2"
+      >
+        <LogOut size={18} />
+        <span>Salir de la tienda</span>
+      </button>
+
+      <BottomSheet
+        isOpen={confirmando}
+        onClose={() => setConfirmando(false)}
+        title="Salir de la tienda"
+      >
+        <div className="space-y-4">
+          <p className="text-body text-fg-secondary">
+            Vas a perder el acceso a las listas y el catálogo de esta tienda.
+            Para volver, alguien del equipo tiene que invitarte de nuevo.
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setConfirmando(false)}
+              disabled={quitar.isPending}
+              className="flex-1 bg-surface-2 hover:bg-border text-fg-secondary font-semibold h-12 px-4 rounded-field transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={onSalir}
+              disabled={quitar.isPending}
+              className="flex-1 bg-alert-critico text-white font-semibold h-12 px-4 rounded-field transition-colors disabled:opacity-50"
+            >
+              {quitar.isPending ? "Saliendo..." : "Salir"}
+            </button>
+          </div>
+        </div>
+      </BottomSheet>
+    </>
+  );
+}
+
+export default function TiendaPage() {
+  const { rol } = useAuth();
+  const esAdmin = rol === "admin";
+
+  return (
+    <AppShell
+      renderHeader={() => (
+        <PageHeader title="Mi tienda" subtitle="Equipo e invitaciones" />
+      )}
+    >
+      <div className="pb-8">
+        <SeccionNombre esAdmin={esAdmin} />
+        <SeccionEquipo esAdmin={esAdmin} />
+        {esAdmin && <SeccionInvitaciones />}
+        <SeccionSalir />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/unirse/page.tsx
+++ b/src/app/unirse/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+  AuthCard,
+  claseBotonPrimario,
+  claseInput,
+  MensajeError,
+} from "@/components/auth/AuthCard";
+import { useAuth } from "@/components/AuthProvider";
+import { canjearInvitacion } from "@/services/equipo";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, Suspense, useState } from "react";
+
+/**
+ * Destino del link de invitación (/unirse?codigo=X, spec §1.1): pública
+ * porque el invitado típico todavía no tiene cuenta. Deslogueado ofrece
+ * registro/login con next= de vuelta acá; logueado canjea directo (sirve
+ * también para sumar una segunda tienda a una cuenta existente).
+ */
+function UnirseContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { user, cargando, refrescarMembresia } = useAuth();
+  const [codigo, setCodigo] = useState(
+    () => searchParams.get("codigo")?.toUpperCase() ?? ""
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+
+  const next = `/unirse?codigo=${encodeURIComponent(codigo)}`;
+
+  async function onCanjear(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setEnviando(true);
+    try {
+      await canjearInvitacion(codigo);
+      await refrescarMembresia();
+      router.replace("/");
+    } catch (err) {
+      setEnviando(false);
+      setError(
+        err instanceof Error && /inválido|vencido|agotado/i.test(err.message)
+          ? "Código inválido, vencido o agotado"
+          : "No se pudo canjear el código. Probá de nuevo."
+      );
+    }
+  }
+
+  if (cargando) {
+    return (
+      <div className="min-h-dvh bg-canvas flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-accent" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <AuthCard
+        titulo="Te invitaron a una tienda"
+        subtitulo="Creá tu cuenta o entrá para sumarte"
+      >
+        {codigo && (
+          <p className="text-center font-mono text-2xl tracking-widest text-fg mb-4">
+            {codigo}
+          </p>
+        )}
+        <div className="space-y-3">
+          <Link
+            href={`/registro?next=${encodeURIComponent(next)}`}
+            className={`${claseBotonPrimario} flex items-center justify-center`}
+          >
+            Crear cuenta
+          </Link>
+          <Link
+            href={`/login?next=${encodeURIComponent(next)}`}
+            className="w-full h-12 rounded-full bg-surface-2 text-fg font-semibold flex items-center justify-center"
+          >
+            Ya tengo cuenta
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      titulo="Unirte a una tienda"
+      subtitulo={`Con la cuenta ${user.email ?? ""}`}
+    >
+      <form onSubmit={onCanjear} className="space-y-3">
+        <input
+          type="text"
+          required
+          maxLength={8}
+          placeholder="Código de invitación"
+          value={codigo}
+          onChange={(e) => setCodigo(e.target.value.toUpperCase())}
+          className={`${claseInput} uppercase tracking-widest text-center font-mono`}
+        />
+        <MensajeError mensaje={error} />
+        <button
+          type="submit"
+          disabled={enviando || codigo.trim().length === 0}
+          className={claseBotonPrimario}
+        >
+          {enviando ? (
+            <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+          ) : (
+            "Unirme a la tienda"
+          )}
+        </button>
+      </form>
+      <div className="mt-4 text-center">
+        <Link href="/" className="text-sm text-fg-secondary">
+          Volver a la app
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}
+
+export default function UnirsePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-dvh bg-canvas flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-accent" />
+        </div>
+      }
+    >
+      <UnirseContent />
+    </Suspense>
+  );
+}

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -8,6 +8,7 @@ import type { User } from "@supabase/supabase-js";
 import { usePathname, useRouter } from "next/navigation";
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -22,6 +23,13 @@ interface AuthContextValue {
    * tienda_miembros. */
   tiendaActiva: string | null;
   rol: RolTienda | null;
+  /** true solo cuando la membresía se consultó ONLINE y vino vacía: el
+   * usuario está logueado pero no pertenece a ninguna tienda (cuenta nueva
+   * o expulsado). Un fetch fallido (offline) NO lo activa. */
+  sinTienda: boolean;
+  /** Re-consulta tienda_miembros (post crear tienda / canjear código /
+   * salir de la tienda). */
+  refrescarMembresia: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue>({
@@ -29,6 +37,8 @@ const AuthContext = createContext<AuthContextValue>({
   cargando: true,
   tiendaActiva: null,
   rol: null,
+  sinTienda: false,
+  refrescarMembresia: async () => {},
 });
 
 export function useAuth(): AuthContextValue {
@@ -58,6 +68,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [rol, setRol] = useState<RolTienda | null>(
     () => useSesionStore.getState().rol
   );
+  const [sinTienda, setSinTienda] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
 
@@ -83,39 +94,50 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  const refrescarMembresia = useCallback(async () => {
+    const { data, error } = await supabase
+      .from("tienda_miembros")
+      .select("tienda_id, rol");
+    // Error (típicamente red/offline): conservar el estado persistido y no
+    // declarar "sin tienda" — el cache local sigue siendo operable.
+    if (error || !data) return;
+    const persistida = useSesionStore.getState().tiendaActivaId;
+    const elegida =
+      data.find((m) => m.tienda_id === persistida) ?? data[0] ?? null;
+    const tiendaId = elegida?.tienda_id ?? null;
+    const rolElegido = (elegida?.rol as RolTienda | undefined) ?? null;
+    setTiendaActiva(tiendaId);
+    setRol(rolElegido);
+    setSinTienda(data.length === 0);
+    useSesionStore.getState().setTienda(tiendaId, rolElegido);
+  }, []);
+
   // Resolver la membresía cuando hay usuario; sin red queda el persistido.
   useEffect(() => {
     setUsuarioOutbox(user?.id ?? null);
     if (!user) {
       setTiendaActiva(null);
       setRol(null);
+      setSinTienda(false);
       return;
     }
-
-    let activo = true;
-    supabase
-      .from("tienda_miembros")
-      .select("tienda_id, rol")
-      .then(({ data, error }) => {
-        if (!activo || error || !data) return;
-        const persistida = useSesionStore.getState().tiendaActivaId;
-        const elegida =
-          data.find((m) => m.tienda_id === persistida) ?? data[0] ?? null;
-        const tiendaId = elegida?.tienda_id ?? null;
-        const rolElegido = (elegida?.rol as RolTienda | undefined) ?? null;
-        setTiendaActiva(tiendaId);
-        setRol(rolElegido);
-        useSesionStore.getState().setTienda(tiendaId, rolElegido);
-      });
-    return () => {
-      activo = false;
-    };
-  }, [user]);
+    refrescarMembresia();
+  }, [user, refrescarMembresia]);
 
   useEffect(() => {
     if (cargando || user) return;
     if (!esRutaPublica(pathname)) router.replace("/login");
   }, [cargando, user, pathname, router]);
+
+  // Cuenta sin membresía en ruta protegida → onboarding (crear tienda o
+  // canjear código). /unirse es pública y queda fuera: quien llega por un
+  // link de invitación canjea ahí mismo.
+  useEffect(() => {
+    if (cargando || !user || !sinTienda) return;
+    if (!esRutaPublica(pathname) && pathname !== "/onboarding") {
+      router.replace("/onboarding");
+    }
+  }, [cargando, user, sinTienda, pathname, router]);
 
   // Sin sesión en ruta protegida: no renderizar el contenido mientras el
   // redirect a /login está en vuelo (evita el flash de la app vacía).
@@ -124,7 +146,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, cargando, tiendaActiva, rol }}>
+    <AuthContext.Provider
+      value={{ user, cargando, tiendaActiva, rol, sinTienda, refrescarMembresia }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/components/reposicion/HistorialCard.tsx
+++ b/src/components/reposicion/HistorialCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import { BottomSheet } from "@/components/ui/BottomSheet";
 import { useEliminarListaHistorial } from "@/hooks/useReposicion";
 import { ItemHistorial, ListaReposicionHistorial } from "@/types";
@@ -23,6 +24,10 @@ export function HistorialCard({ lista }: HistorialCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const eliminarLista = useEliminarListaHistorial();
+  // El historial es el registro de auditoría: borrar es de admin (la RLS
+  // ya lo bloquea server-side; acá se oculta la acción, spec Fase 3).
+  const { rol } = useAuth();
+  const puedeEliminar = rol === "admin";
 
   const handleDelete = async () => {
     try {
@@ -181,13 +186,15 @@ export function HistorialCard({ lista }: HistorialCardProps) {
                 icon={Package}
               />
 
-              <button
-                onClick={() => setShowDeleteModal(true)}
-                className="w-full mt-4 h-12 bg-alert-critico/10 hover:bg-alert-critico/20 text-alert-critico font-semibold rounded-field transition-colors flex items-center justify-center gap-2"
-              >
-                <Trash2 size={18} />
-                <span>Eliminar esta lista</span>
-              </button>
+              {puedeEliminar && (
+                <button
+                  onClick={() => setShowDeleteModal(true)}
+                  className="w-full mt-4 h-12 bg-alert-critico/10 hover:bg-alert-critico/20 text-alert-critico font-semibold rounded-field transition-colors flex items-center justify-center gap-2"
+                >
+                  <Trash2 size={18} />
+                  <span>Eliminar esta lista</span>
+                </button>
+              )}
             </div>
           </m.div>
         )}

--- a/src/hooks/useEquipo.ts
+++ b/src/hooks/useEquipo.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useAuth } from "@/components/AuthProvider";
+import {
+  invitacionesKey,
+  miembrosKey,
+  SIN_TIENDA,
+  tiendaMetaKey,
+} from "@/lib/queryKeys";
+import * as equipoService from "@/services/equipo";
+import type { RolTienda } from "@/store/sesion";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+/**
+ * Hooks de la pantalla /tienda (Fase 3): nombre, miembros, roles e
+ * invitaciones. Online-only: sin outbox ni optimismo — los errores del
+ * servidor (guard "último admin", permisos) son parte del flujo y deben
+ * llegar al caller tal cual.
+ */
+
+function useEquipoScope() {
+  const { tiendaActiva, rol } = useAuth();
+  const tiendaId = tiendaActiva ?? SIN_TIENDA;
+  return {
+    tiendaActiva,
+    esAdmin: rol === "admin",
+    META_KEY: tiendaMetaKey(tiendaId),
+    MIEMBROS_KEY: miembrosKey(tiendaId),
+    INVITACIONES_KEY: invitacionesKey(tiendaId),
+  };
+}
+
+export function useNombreTienda() {
+  const { tiendaActiva, META_KEY } = useEquipoScope();
+  return useQuery({
+    queryKey: META_KEY,
+    queryFn: () => equipoService.obtenerNombreTienda(tiendaActiva!),
+    enabled: !!tiendaActiva,
+  });
+}
+
+export function useRenombrarTienda() {
+  const { tiendaActiva, META_KEY } = useEquipoScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (nombre: string) =>
+      equipoService.renombrarTienda(tiendaActiva!, nombre),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: META_KEY }),
+  });
+}
+
+export function useMiembros() {
+  const { tiendaActiva, MIEMBROS_KEY } = useEquipoScope();
+  return useQuery({
+    queryKey: MIEMBROS_KEY,
+    queryFn: () => equipoService.listarMiembros(tiendaActiva!),
+    enabled: !!tiendaActiva,
+  });
+}
+
+export function useCambiarRol() {
+  const { tiendaActiva, MIEMBROS_KEY } = useEquipoScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId, rol }: { userId: string; rol: RolTienda }) =>
+      equipoService.cambiarRolMiembro(tiendaActiva!, userId, rol),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: MIEMBROS_KEY }),
+  });
+}
+
+/** Expulsar a otro miembro o salir uno mismo (misma operación de DB). */
+export function useQuitarMiembro() {
+  const { tiendaActiva, MIEMBROS_KEY } = useEquipoScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId: string) =>
+      equipoService.quitarMiembro(tiendaActiva!, userId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: MIEMBROS_KEY }),
+  });
+}
+
+export function useInvitaciones() {
+  const { tiendaActiva, esAdmin, INVITACIONES_KEY } = useEquipoScope();
+  return useQuery({
+    queryKey: INVITACIONES_KEY,
+    queryFn: () => equipoService.listarInvitaciones(tiendaActiva!),
+    // RLS solo se las muestra a admins; ni consultarlas como empleado.
+    enabled: !!tiendaActiva && esAdmin,
+  });
+}
+
+export function useGenerarInvitacion() {
+  const { tiendaActiva, INVITACIONES_KEY } = useEquipoScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      rol,
+      maxUsos,
+      dias,
+    }: {
+      rol: RolTienda;
+      maxUsos: number;
+      dias: number;
+    }) => equipoService.generarInvitacion(tiendaActiva!, rol, maxUsos, dias),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: INVITACIONES_KEY }),
+  });
+}
+
+export function useRevocarInvitacion() {
+  const { INVITACIONES_KEY } = useEquipoScope();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (invitacionId: string) =>
+      equipoService.revocarInvitacion(invitacionId),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: INVITACIONES_KEY }),
+  });
+}

--- a/src/lib/__tests__/navegacion.test.ts
+++ b/src/lib/__tests__/navegacion.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { destinoSeguro } from "@/lib/navegacion";
+
+describe("destinoSeguro", () => {
+  it("acepta rutas relativas de la app", () => {
+    expect(destinoSeguro("/unirse?codigo=ABC23456")).toBe(
+      "/unirse?codigo=ABC23456"
+    );
+    expect(destinoSeguro("/tienda")).toBe("/tienda");
+  });
+
+  it("rechaza URLs absolutas y protocol-relative (open redirect)", () => {
+    expect(destinoSeguro("https://evil.com")).toBe("/");
+    expect(destinoSeguro("//evil.com")).toBe("/");
+    expect(destinoSeguro("javascript:alert(1)")).toBe("/");
+  });
+
+  it("cae a / cuando falta el parámetro", () => {
+    expect(destinoSeguro(null)).toBe("/");
+    expect(destinoSeguro(undefined)).toBe("/");
+    expect(destinoSeguro("")).toBe("/");
+  });
+});

--- a/src/lib/navegacion.ts
+++ b/src/lib/navegacion.ts
@@ -1,0 +1,10 @@
+/**
+ * Sanea el parámetro `next` de login/registro (adónde volver después de
+ * autenticarse, p. ej. /unirse?codigo=X). Solo se aceptan rutas relativas
+ * de esta app: un valor absoluto o protocol-relative ("//evil.com") sería
+ * un open redirect.
+ */
+export function destinoSeguro(next: string | null | undefined): string {
+  if (!next || !next.startsWith("/") || next.startsWith("//")) return "/";
+  return next;
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -36,3 +36,16 @@ export function catalogoCompletoKey(tiendaId: string) {
 export function eanQueryKey(tiendaId: string, ean: string) {
   return ["tienda", tiendaId, "producto", "ean", ean] as const;
 }
+
+// Gestión de equipo (Fase 3). No entran en esQueryPersistible a propósito:
+// miembros/invitaciones se consultan online (la pantalla /tienda no es un
+// flujo offline) y los emails no deben quedar en el cache IDB.
+export function tiendaMetaKey(tiendaId: string) {
+  return ["tienda", tiendaId, "meta"] as const;
+}
+export function miembrosKey(tiendaId: string) {
+  return ["tienda", tiendaId, "equipo", "miembros"] as const;
+}
+export function invitacionesKey(tiendaId: string) {
+  return ["tienda", tiendaId, "equipo", "invitaciones"] as const;
+}

--- a/src/services/equipo.ts
+++ b/src/services/equipo.ts
@@ -1,0 +1,172 @@
+import { supabase } from "@/lib/supabase";
+import type { RolTienda } from "@/store/sesion";
+
+/**
+ * Gestión de tienda y equipo (Fase 3, docs/SPECMULTIUSER.md §3.3):
+ * tiendas, miembros, roles e invitaciones. Todo online-only — esta capa no
+ * pasa por el outbox: administrar el equipo sin conexión no es un caso de
+ * uso y los errores (guard "último admin", código inválido) deben verse
+ * en el momento.
+ */
+
+export interface MiembroTienda {
+  userId: string;
+  email: string;
+  rol: RolTienda;
+  creadoAt: Date;
+}
+
+export interface InvitacionTienda {
+  id: string;
+  codigo: string;
+  rol: RolTienda;
+  usos: number;
+  maxUsos: number;
+  expiraAt: Date;
+  revocada: boolean;
+  creadaAt: Date;
+}
+
+interface MiembroRow {
+  user_id: string;
+  email: string;
+  rol: RolTienda;
+  creado_at: string;
+}
+
+interface InvitacionRow {
+  id: string;
+  codigo: string;
+  rol: RolTienda;
+  usos: number;
+  max_usos: number;
+  expira_at: string;
+  revocada: boolean;
+  created_at: string;
+}
+
+export async function obtenerNombreTienda(tiendaId: string): Promise<string> {
+  const { data, error } = await supabase
+    .from("tiendas")
+    .select("nombre")
+    .eq("id", tiendaId)
+    .single();
+  if (error) throw error;
+  return data.nombre as string;
+}
+
+export async function renombrarTienda(
+  tiendaId: string,
+  nombre: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("tiendas")
+    .update({ nombre: nombre.trim() })
+    .eq("id", tiendaId);
+  if (error) throw error;
+}
+
+export async function listarMiembros(
+  tiendaId: string
+): Promise<MiembroTienda[]> {
+  const { data, error } = await supabase.rpc("miembros_de_tienda", {
+    p_tienda_id: tiendaId,
+  });
+  if (error) throw error;
+  return ((data ?? []) as MiembroRow[]).map((row) => ({
+    userId: row.user_id,
+    email: row.email,
+    rol: row.rol,
+    creadoAt: new Date(row.creado_at),
+  }));
+}
+
+export async function cambiarRolMiembro(
+  tiendaId: string,
+  userId: string,
+  rol: RolTienda
+): Promise<void> {
+  const { error } = await supabase
+    .from("tienda_miembros")
+    .update({ rol })
+    .eq("tienda_id", tiendaId)
+    .eq("user_id", userId);
+  if (error) throw error;
+}
+
+/** Expulsar a otro miembro (admin) o salir uno mismo: misma fila, misma
+ * policy (delete admin-o-propio). El guard "último admin" puede rechazarlo. */
+export async function quitarMiembro(
+  tiendaId: string,
+  userId: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("tienda_miembros")
+    .delete()
+    .eq("tienda_id", tiendaId)
+    .eq("user_id", userId);
+  if (error) throw error;
+}
+
+export async function listarInvitaciones(
+  tiendaId: string
+): Promise<InvitacionTienda[]> {
+  const { data, error } = await supabase
+    .from("tienda_invitaciones")
+    .select("id, codigo, rol, usos, max_usos, expira_at, revocada, created_at")
+    .eq("tienda_id", tiendaId)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return ((data ?? []) as InvitacionRow[]).map((row) => ({
+    id: row.id,
+    codigo: row.codigo,
+    rol: row.rol,
+    usos: row.usos,
+    maxUsos: row.max_usos,
+    expiraAt: new Date(row.expira_at),
+    revocada: row.revocada,
+    creadaAt: new Date(row.created_at),
+  }));
+}
+
+export async function generarInvitacion(
+  tiendaId: string,
+  rol: RolTienda,
+  maxUsos: number,
+  dias: number
+): Promise<string> {
+  const { data, error } = await supabase.rpc("generar_codigo_invitacion", {
+    p_tienda_id: tiendaId,
+    p_rol: rol,
+    p_max_usos: maxUsos,
+    p_dias: dias,
+  });
+  if (error) throw error;
+  return data as string;
+}
+
+export async function revocarInvitacion(invitacionId: string): Promise<void> {
+  const { error } = await supabase
+    .from("tienda_invitaciones")
+    .update({ revocada: true })
+    .eq("id", invitacionId);
+  if (error) throw error;
+}
+
+/** Devuelve el id de la tienda a la que se unió. */
+export async function canjearInvitacion(codigo: string): Promise<string> {
+  const { data, error } = await supabase.rpc("canjear_invitacion", {
+    p_codigo: codigo.trim().toUpperCase(),
+  });
+  if (error) throw error;
+  return data as string;
+}
+
+/** Devuelve el id de la tienda creada (el creador queda como admin). */
+export async function crearTienda(nombre: string): Promise<string> {
+  const { data, error } = await supabase.rpc("crear_tienda_con_admin", {
+    p_nombre: nombre.trim(),
+  });
+  if (error) throw error;
+  return data as string;
+}

--- a/src/tests/integration/aislamiento-rls.test.ts
+++ b/src/tests/integration/aislamiento-rls.test.ts
@@ -354,3 +354,76 @@ describe("invitaciones y multi-membresía", () => {
     expect(varianteId).toBeTruthy();
   });
 });
+
+describe("gestión de equipo (Fase 3, migración 0016)", () => {
+  // Estado heredado del describe anterior: A tiene a userA (admin) y a
+  // userB (empleado, vía canje); B tiene solo a userB (admin).
+
+  it("miembros_de_tienda devuelve los emails a un miembro", async () => {
+    const { data, error } = await userB.client.rpc("miembros_de_tienda", {
+      p_tienda_id: tiendaA,
+    });
+    expect(error).toBeNull();
+    const miembros = data as { user_id: string; email: string; rol: string }[];
+    expect(miembros).toHaveLength(2);
+    expect(miembros.map((m) => m.email)).toEqual(
+      expect.arrayContaining([userA.email, userB.email])
+    );
+    expect(miembros.find((m) => m.user_id === userA.id)?.rol).toBe("admin");
+    expect(miembros.find((m) => m.user_id === userB.id)?.rol).toBe("empleado");
+  });
+
+  it("miembros_de_tienda de una tienda ajena devuelve vacío", async () => {
+    // userA nunca fue miembro de B: ni filas ni error que revele existencia.
+    const { data, error } = await userA.client.rpc("miembros_de_tienda", {
+      p_tienda_id: tiendaB,
+    });
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+
+  it("el último admin no puede degradarse a empleado", async () => {
+    const { error } = await userA.client
+      .from("tienda_miembros")
+      .update({ rol: "empleado" })
+      .eq("tienda_id", tiendaA)
+      .eq("user_id", userA.id);
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/sin admin/i);
+  });
+
+  it("el último admin no puede salir de la tienda", async () => {
+    const { error } = await userA.client
+      .from("tienda_miembros")
+      .delete()
+      .eq("tienda_id", tiendaA)
+      .eq("user_id", userA.id);
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/sin admin/i);
+  });
+
+  it("con otro admin nombrado, el fundador sí puede salir", async () => {
+    // userA promueve a userB…
+    const { error: promoError } = await userA.client
+      .from("tienda_miembros")
+      .update({ rol: "admin" })
+      .eq("tienda_id", tiendaA)
+      .eq("user_id", userB.id);
+    expect(promoError).toBeNull();
+
+    // …y ahora sí puede irse.
+    const { error: salidaError } = await userA.client
+      .from("tienda_miembros")
+      .delete()
+      .eq("tienda_id", tiendaA)
+      .eq("user_id", userA.id);
+    expect(salidaError).toBeNull();
+
+    // Para userA la tienda A dejó de existir.
+    const { data } = await userA.client
+      .from("tiendas")
+      .select("id")
+      .eq("id", tiendaA);
+    expect(data).toEqual([]);
+  });
+});

--- a/supabase/migrations/0016_equipo_y_guards.sql
+++ b/supabase/migrations/0016_equipo_y_guards.sql
@@ -1,0 +1,77 @@
+-- Fase 3 multi-tienda: gestión de equipo (docs/SPECMULTIUSER.md §3.3 y
+-- Roadmap Fase 3). Dos piezas de DB que la UI de /tienda necesita:
+--
+-- 1. Guard "último admin": una tienda nunca puede quedarse sin admin, ni
+--    por degradación de rol ni por expulsión/salida. Las policies de 0014
+--    ya permiten a un admin cambiar roles y borrar membresías (y a
+--    cualquiera borrar la propia); este trigger agrega el invariante que
+--    ninguna policy puede expresar (mira OTRAS filas de la tabla).
+--
+-- 2. miembros_de_tienda(): la lista de miembros con email. Los emails
+--    viven en auth.users, que el cliente no puede leer; la RPC es DEFINER
+--    con guard de membresía interno (regla de 0015: el guard que la policy
+--    no aplica va DENTRO de la función, con su revoke en la misma
+--    migración).
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Guard último admin
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- Corre como invoker: los SELECT ven la tienda vía RLS porque quien
+-- dispara el trigger es siempre miembro (policies de UPDATE/DELETE de
+-- tienda_miembros). Si la tienda ya no existe (cascada de un borrado
+-- administrativo de tiendas vía service_role), el guard deja pasar.
+-- Nota aceptada: borrar de auth.users al único admin de una tienda viva
+-- también dispara la cascada y es bloqueado — es el mismo invariante
+-- (primero se transfiere la tienda o se borra la tienda, después el user).
+create or replace function proteger_ultimo_admin() returns trigger
+language plpgsql set search_path = public as $$
+begin
+  if not exists (select 1 from tiendas where id = old.tienda_id) then
+    return coalesce(new, old);
+  end if;
+
+  if old.rol = 'admin'
+     and (tg_op = 'DELETE' or new.rol <> 'admin')
+     and not exists (
+       select 1 from tienda_miembros
+       where tienda_id = old.tienda_id
+         and rol = 'admin'
+         and user_id <> old.user_id
+     ) then
+    raise exception 'La tienda no puede quedarse sin admin';
+  end if;
+
+  return coalesce(new, old);
+end; $$;
+
+create trigger trg_tienda_miembros_ultimo_admin
+  before update or delete on tienda_miembros
+  for each row execute function proteger_ultimo_admin();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Lista de miembros con email
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- Un no-miembro recibe 0 filas (el guard está en el WHERE): suficiente
+-- para la UI y no filtra ni la existencia de la tienda.
+create function miembros_de_tienda(p_tienda_id uuid)
+returns table (user_id uuid, email text, rol text, creado_at timestamptz)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select tm.user_id, u.email::text, tm.rol, tm.created_at
+  from tienda_miembros tm
+  join auth.users u on u.id = tm.user_id
+  where tm.tienda_id = p_tienda_id
+    and p_tienda_id in (
+      select tienda_id from tienda_miembros
+      where tienda_miembros.user_id = (select auth.uid())
+    )
+  order by tm.created_at;
+$$;
+
+revoke execute on function miembros_de_tienda(uuid) from public, anon;
+grant execute on function miembros_de_tienda(uuid) to authenticated, service_role;


### PR DESCRIPTION
Implementa la **Fase 3** de `docs/SPECMULTIUSER.md`: onboarding post-registro, link de invitación, pantalla de gestión de equipo, UI condicionada por rol y el guard "último admin".

## Base de datos — migración `0016_equipo_y_guards.sql` (⚠️ NO se aplica con este merge)

- **Guard "último admin"**: trigger `BEFORE UPDATE OR DELETE` en `tienda_miembros` que impide que una tienda quede sin admin — ni degradando el rol ni saliendo/expulsando. Deja pasar la cascada de un borrado administrativo de la tienda (la fila de `tiendas` ya no existe cuando dispara).
- **`miembros_de_tienda(p_tienda_id)`**: los emails viven en `auth.users` (ilegible para el cliente); RPC `SECURITY DEFINER` con el guard de membresía en el `WHERE` (un no-miembro recibe 0 filas, sin revelar existencia) y `revoke` a `public`/`anon` en la misma migración.

## Cliente

- **AuthProvider**: expone `sinTienda` (la membresía se consultó *online* y vino vacía — un fetch fallido offline no lo activa, el cache local sigue operable) y `refrescarMembresia()`. Cuenta sin tienda en ruta protegida → `/onboarding`.
- **`/onboarding`**: crear tienda (→ `crear_tienda_con_admin`) o canjear código (→ `canjear_invitacion`); cerrar sesión como escape.
- **`/unirse?codigo=X`** (pública): destino del link de invitación. Deslogueado ofrece registro/login con `next=` de vuelta al canje; logueado canjea directo (sirve para sumar una segunda tienda).
- **`next=` saneado**: `destinoSeguro()` solo acepta rutas relativas de la app (sin open redirect).
- **`/tienda`**: renombrar (admin), miembros con email + rol vía `miembros_de_tienda`, cambiar rol/expulsar (admin), invitaciones (generar con rol y usos — vencen a los 7 días —, copiar link, revocar) y "salir de la tienda" con el error del guard surfaceado.
- **UI por rol**: el botón "Eliminar esta lista" del historial de reposición se oculta a empleados (la RLS ya lo bloqueaba server-side; el historial de vencimiento no tiene acciones de borrado).
- Header del home gana el acceso a `/tienda`.

## Tests

- `destinoSeguro` (open redirect) en unidad — **172/172 verdes**, `tsc` limpio, lint sin errores nuevos, `next build` OK.
- La suite de integración gana: `miembros_de_tienda` (miembro ve los emails, ajeno recibe vacío) y el ciclo del último admin (no puede degradarse ni salir; con otro admin nombrado, sí).

## Deploy

Menos delicado que la Fase 2: la 0016 es **aditiva** (trigger + RPC nueva). Orden: aplicar 0016 → merge/deploy → habilitar "Allow new users to sign up" en el dashboard de Auth (recién ahora es seguro: una cuenta nueva sin membresía no ve ningún dato y cae en el onboarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW)_