### PR TITLE
Fase 3.1: perfiles con nombre, listas de reposición privadas y equipo admin-only

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BotonCerrarSesion } from "@/components/BotonCerrarSesion";
+import { useAuth } from "@/components/AuthProvider";
 import { OutboxBadge } from "@/components/OutboxBadge";
 import { ScanFlow } from "@/components/scanner/ScanFlow";
 import { ProductSearchSheet } from "@/components/search/ProductSearchSheet";
@@ -15,7 +15,7 @@ import { useNotificacionesVencimiento } from "@/hooks/useNotificacionesVencimien
 import { springGentle } from "@/lib/motion";
 import { ActiveView, useUiStore } from "@/store/ui";
 import { AnimatePresence, motion as m } from "framer-motion";
-import { History, Loader2, Search, Store } from "lucide-react";
+import { History, Loader2, Search, Store, UserRound } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
@@ -48,6 +48,7 @@ function HomePageContent() {
   const { activeView, setActiveView, scannerOpen, openScanner, closeScanner } =
     useUiStore();
   const [searchOpen, setSearchOpen] = useState(false);
+  const { rol } = useAuth();
   // Badge del ícono/tab + notificaciones locales de items urgentes.
   const { urgentesCount } = useNotificacionesVencimiento();
 
@@ -98,16 +99,24 @@ function HomePageContent() {
                 >
                   <History size={22} />
                 </Link>
+                {rol === "admin" && (
+                  <Link
+                    href="/tienda"
+                    aria-label="Mi tienda y equipo"
+                    className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors"
+                  >
+                    <Store size={22} />
+                  </Link>
+                )}
                 <Link
-                  href="/tienda"
-                  aria-label="Mi tienda y equipo"
+                  href="/perfil"
+                  aria-label="Tu perfil"
                   className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors"
                 >
-                  <Store size={22} />
+                  <UserRound size={22} />
                 </Link>
                 <OutboxBadge />
                 <ThemeToggle />
-                <BotonCerrarSesion />
               </>
             }
             bottomSlot={

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useAuth } from "@/components/AuthProvider";
+import { AppShell } from "@/components/shell/AppShell";
+import { PageHeader } from "@/components/shell/PageHeader";
+import { BottomSheet } from "@/components/ui/BottomSheet";
+import { useCerrarSesion } from "@/hooks/useCerrarSesion";
+import {
+  useActualizarMiNombre,
+  useMiPerfil,
+  useNombreTienda,
+  useQuitarMiembro,
+} from "@/hooks/useEquipo";
+import {
+  Check,
+  ChevronRight,
+  Loader2,
+  LogOut,
+  Pencil,
+  ShieldCheck,
+  Store,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import toast from "react-hot-toast";
+
+/** Nombre propio, editable: es lo que ven los compañeros en la atribución
+ * de items y listas. */
+function SeccionNombrePropio() {
+  const { data: nombre, isPending } = useMiPerfil();
+  const actualizar = useActualizarMiNombre();
+  const [editando, setEditando] = useState(false);
+  const [borrador, setBorrador] = useState("");
+
+  const guardar = async () => {
+    const limpio = borrador.trim();
+    if (!limpio || limpio === nombre) {
+      setEditando(false);
+      return;
+    }
+    try {
+      await actualizar.mutateAsync(limpio);
+      toast.success("Nombre actualizado");
+      setEditando(false);
+    } catch {
+      toast.error("No se pudo actualizar el nombre");
+    }
+  };
+
+  return (
+    <div className="island p-4 mb-4">
+      <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide mb-2">
+        Tu nombre
+      </div>
+      {editando ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            maxLength={60}
+            value={borrador}
+            onChange={(e) => setBorrador(e.target.value)}
+            className="flex-1 h-11 px-3 rounded-field bg-surface-2 text-fg outline-none focus:ring-2 focus:ring-accent"
+            autoFocus
+          />
+          <button
+            onClick={guardar}
+            disabled={actualizar.isPending}
+            aria-label="Guardar nombre"
+            className="w-11 h-11 flex items-center justify-center rounded-full bg-accent text-on-accent disabled:opacity-50"
+          >
+            {actualizar.isPending ? (
+              <Loader2 size={18} className="animate-spin" />
+            ) : (
+              <Check size={18} />
+            )}
+          </button>
+          <button
+            onClick={() => setEditando(false)}
+            aria-label="Cancelar"
+            className="w-11 h-11 flex items-center justify-center rounded-full bg-surface-2 text-fg-secondary"
+          >
+            <X size={18} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-title-3 text-fg font-semibold truncate">
+            {isPending ? "…" : nombre}
+          </span>
+          <button
+            onClick={() => {
+              setBorrador(nombre ?? "");
+              setEditando(true);
+            }}
+            aria-label="Editar nombre"
+            className="w-11 h-11 flex items-center justify-center rounded-full text-fg-secondary hover:bg-surface-2 transition-colors shrink-0"
+          >
+            <Pencil size={18} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SeccionTienda() {
+  const { rol } = useAuth();
+  const { data: nombreTienda } = useNombreTienda();
+  const esAdmin = rol === "admin";
+
+  return (
+    <div className="island p-4 mb-4">
+      <div className="text-footnote font-semibold text-fg-secondary uppercase tracking-wide mb-2">
+        Tu tienda
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-body text-fg font-semibold truncate">
+            {nombreTienda ?? "…"}
+          </div>
+          <div className="mt-1">
+            {esAdmin ? (
+              <span className="inline-flex items-center gap-1 bg-accent-soft text-accent px-2.5 py-1 rounded-chip text-caption font-semibold">
+                <ShieldCheck size={12} /> Admin
+              </span>
+            ) : (
+              <span className="bg-surface-2 text-fg-secondary px-2.5 py-1 rounded-chip text-caption font-semibold">
+                Empleado
+              </span>
+            )}
+          </div>
+        </div>
+        {esAdmin && (
+          <Link
+            href="/tienda"
+            className="shrink-0 h-11 px-4 rounded-full bg-surface-2 text-fg font-semibold text-subhead flex items-center gap-1.5 hover:bg-border transition-colors"
+          >
+            <Store size={16} /> Gestionar <ChevronRight size={14} />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SeccionSalirDeTienda() {
+  const router = useRouter();
+  const { user, refrescarMembresia } = useAuth();
+  const quitar = useQuitarMiembro();
+  const [confirmando, setConfirmando] = useState(false);
+
+  const onSalir = async () => {
+    if (!user) return;
+    try {
+      await quitar.mutateAsync(user.id);
+      await refrescarMembresia();
+      router.replace("/onboarding");
+    } catch (err) {
+      toast.error(
+        err instanceof Error && err.message.includes("sin admin")
+          ? "La tienda no puede quedarse sin admin: nombrá otro admin primero"
+          : "No se pudo salir de la tienda"
+      );
+      setConfirmando(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setConfirmando(true)}
+        className="w-full h-12 bg-alert-critico/10 hover:bg-alert-critico/20 text-alert-critico font-semibold rounded-field transition-colors flex items-center justify-center gap-2 mb-3"
+      >
+        <LogOut size={18} />
+        <span>Salir de la tienda</span>
+      </button>
+
+      <BottomSheet
+        isOpen={confirmando}
+        onClose={() => setConfirmando(false)}
+        title="Salir de la tienda"
+      >
+        <div className="space-y-4">
+          <p className="text-body text-fg-secondary">
+            Vas a perder el acceso a las listas y el catálogo de esta tienda.
+            Para volver, alguien del equipo tiene que invitarte de nuevo.
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setConfirmando(false)}
+              disabled={quitar.isPending}
+              className="flex-1 bg-surface-2 hover:bg-border text-fg-secondary font-semibold h-12 px-4 rounded-field transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={onSalir}
+              disabled={quitar.isPending}
+              className="flex-1 bg-alert-critico text-white font-semibold h-12 px-4 rounded-field transition-colors disabled:opacity-50"
+            >
+              {quitar.isPending ? "Saliendo..." : "Salir"}
+            </button>
+          </div>
+        </div>
+      </BottomSheet>
+    </>
+  );
+}
+
+export default function PerfilPage() {
+  const { user } = useAuth();
+  const { cerrarSesion, cerrando } = useCerrarSesion();
+
+  return (
+    <AppShell
+      renderHeader={() => (
+        <PageHeader title="Tu perfil" subtitle={user?.email ?? undefined} />
+      )}
+    >
+      <div className="pb-8">
+        <SeccionNombrePropio />
+        <SeccionTienda />
+        <SeccionSalirDeTienda />
+        <button
+          onClick={cerrarSesion}
+          disabled={cerrando}
+          className="w-full h-12 bg-surface-2 hover:bg-border text-fg-secondary font-semibold rounded-field transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+        >
+          {cerrando ? (
+            <Loader2 size={18} className="animate-spin" />
+          ) : (
+            <LogOut size={18} />
+          )}
+          <span>Cerrar sesión</span>
+        </button>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -19,6 +19,7 @@ function RegistroContent() {
   // Adónde seguir post-registro: /unirse?codigo=X cuando viene de una
   // invitación; sin next, AuthProvider manda la cuenta nueva a /onboarding.
   const next = destinoSeguro(searchParams.get("next"));
+  const [nombre, setNombre] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -32,6 +33,9 @@ function RegistroContent() {
     const { data, error: signUpError } = await supabase.auth.signUp({
       email: email.trim(),
       password,
+      // El trigger de DB (0017) crea el perfil con este nombre; es lo que
+      // ven los compañeros en "agregado por" / "guardada por".
+      options: { data: { nombre: nombre.trim() } },
     });
     setEnviando(false);
     if (signUpError) {
@@ -69,6 +73,16 @@ function RegistroContent() {
   return (
     <AuthCard titulo="Crear cuenta" subtitulo="Para el equipo de tu tienda">
       <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type="text"
+          autoComplete="name"
+          required
+          maxLength={60}
+          placeholder="Tu nombre (lo ve tu equipo)"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+          className={claseInput}
+        />
         <input
           type="email"
           autoComplete="email"

--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -20,7 +20,6 @@ import {
   Check,
   Copy,
   Loader2,
-  LogOut,
   Pencil,
   Plus,
   ShieldCheck,
@@ -29,7 +28,7 @@ import {
   X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 
 const MENSAJE_ULTIMO_ADMIN = "La tienda no puede quedarse sin admin";
@@ -186,12 +185,15 @@ function SeccionEquipo({ esAdmin }: { esAdmin: boolean }) {
             <div key={m.userId} className="flex items-center gap-3">
               <div className="flex-1 min-w-0">
                 <div className="text-body text-fg truncate">
-                  {m.email}
+                  {m.nombre}
                   {esYo && (
                     <span className="text-fg-tertiary text-footnote ml-1.5">
                       (vos)
                     </span>
                   )}
+                </div>
+                <div className="text-footnote text-fg-tertiary truncate">
+                  {m.email}
                 </div>
                 <div className="mt-1">
                   <ChipRol rol={m.rol} />
@@ -445,81 +447,35 @@ function useRevocarInvitacionConToast() {
   };
 }
 
-function SeccionSalir() {
-  const router = useRouter();
-  const { user, refrescarMembresia } = useAuth();
-  const quitar = useQuitarMiembro();
-  const [confirmando, setConfirmando] = useState(false);
-
-  const onSalir = async () => {
-    if (!user) return;
-    try {
-      await quitar.mutateAsync(user.id);
-      await refrescarMembresia();
-      router.replace("/onboarding");
-    } catch (err) {
-      toast.error(mensajeDeError(err, "No se pudo salir de la tienda"));
-      setConfirmando(false);
-    }
-  };
-
-  return (
-    <>
-      <button
-        onClick={() => setConfirmando(true)}
-        className="w-full h-12 bg-alert-critico/10 hover:bg-alert-critico/20 text-alert-critico font-semibold rounded-field transition-colors flex items-center justify-center gap-2"
-      >
-        <LogOut size={18} />
-        <span>Salir de la tienda</span>
-      </button>
-
-      <BottomSheet
-        isOpen={confirmando}
-        onClose={() => setConfirmando(false)}
-        title="Salir de la tienda"
-      >
-        <div className="space-y-4">
-          <p className="text-body text-fg-secondary">
-            Vas a perder el acceso a las listas y el catálogo de esta tienda.
-            Para volver, alguien del equipo tiene que invitarte de nuevo.
-          </p>
-          <div className="flex gap-3">
-            <button
-              onClick={() => setConfirmando(false)}
-              disabled={quitar.isPending}
-              className="flex-1 bg-surface-2 hover:bg-border text-fg-secondary font-semibold h-12 px-4 rounded-field transition-colors"
-            >
-              Cancelar
-            </button>
-            <button
-              onClick={onSalir}
-              disabled={quitar.isPending}
-              className="flex-1 bg-alert-critico text-white font-semibold h-12 px-4 rounded-field transition-colors disabled:opacity-50"
-            >
-              {quitar.isPending ? "Saliendo..." : "Salir"}
-            </button>
-          </div>
-        </div>
-      </BottomSheet>
-    </>
-  );
-}
-
 export default function TiendaPage() {
-  const { rol } = useAuth();
+  const router = useRouter();
+  const { cargando, rol } = useAuth();
   const esAdmin = rol === "admin";
+
+  // Pantalla exclusiva de admins: un empleado ni la ve (además del
+  // hardening server-side de la 0017, que le devuelve vacío igual).
+  useEffect(() => {
+    if (!cargando && rol === "empleado") router.replace("/");
+  }, [cargando, rol, router]);
+
+  if (!esAdmin) {
+    return (
+      <div className="h-dvh bg-canvas flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-accent" />
+      </div>
+    );
+  }
 
   return (
     <AppShell
       renderHeader={() => (
-        <PageHeader title="Mi tienda" subtitle="Equipo e invitaciones" />
+        <PageHeader title="Mi tienda" subtitle="Equipo e invitaciones" backHref="/perfil" />
       )}
     >
       <div className="pb-8">
         <SeccionNombre esAdmin={esAdmin} />
         <SeccionEquipo esAdmin={esAdmin} />
-        {esAdmin && <SeccionInvitaciones />}
-        <SeccionSalir />
+        <SeccionInvitaciones />
       </div>
     </AppShell>
   );

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -95,9 +95,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const refrescarMembresia = useCallback(async () => {
+    const uid = (await supabase.auth.getSession()).data.session?.user?.id;
+    if (!uid) return;
+    // Filtrar por user_id es imprescindible, no defensivo: RLS le muestra a
+    // un admin TODAS las membresías de su tienda — sin el eq(), data[0]
+    // puede ser la fila de otro miembro y el rol adoptado sería el ajeno.
     const { data, error } = await supabase
       .from("tienda_miembros")
-      .select("tienda_id, rol");
+      .select("tienda_id, rol")
+      .eq("user_id", uid);
     // Error (típicamente red/offline): conservar el estado persistido y no
     // declarar "sin tienda" — el cache local sigue siendo operable.
     if (error || !data) return;

--- a/src/components/reposicion/HistorialCard.tsx
+++ b/src/components/reposicion/HistorialCard.tsx
@@ -116,6 +116,12 @@ export function HistorialCard({ lista }: HistorialCardProps) {
             <div className="flex-1">
               <div className="text-footnote text-fg-secondary mb-1">
                 {formatearFecha(lista.fechaGuardado)}
+                {lista.guardadaPorNombre && (
+                  <span className="text-fg-tertiary">
+                    {" "}
+                    · por {lista.guardadaPorNombre}
+                  </span>
+                )}
               </div>
               <div className="flex flex-wrap gap-2 mt-2">
                 <div className="bg-accent-soft text-accent px-3 py-1 rounded-chip text-caption font-semibold">

--- a/src/components/vencimiento/VencimientoItem.tsx
+++ b/src/components/vencimiento/VencimientoItem.tsx
@@ -117,6 +117,10 @@ export function VencimientoItem({
             {item.cantidad && <span className="font-medium">Cantidad: {item.cantidad}</span>}
 
             {item.lote && <span className="text-fg-secondary">Lote: {item.lote}</span>}
+
+            {item.agregadoPorNombre && (
+              <span className="text-fg-tertiary">por {item.agregadoPorNombre}</span>
+            )}
           </div>
         </div>
 

--- a/src/hooks/useEquipo.ts
+++ b/src/hooks/useEquipo.ts
@@ -30,6 +30,28 @@ function useEquipoScope() {
   };
 }
 
+/** Nombre propio (perfiles). Key por usuario, no por tienda: el perfil es
+ * de la cuenta. */
+export function useMiPerfil() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ["perfil", user?.id ?? "anon"],
+    queryFn: () => equipoService.obtenerMiNombre(user!.id),
+    enabled: !!user,
+  });
+}
+
+export function useActualizarMiNombre() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (nombre: string) =>
+      equipoService.actualizarMiNombre(user!.id, nombre),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["perfil", user?.id] }),
+  });
+}
+
 export function useNombreTienda() {
   const { tiendaActiva, META_KEY } = useEquipoScope();
   return useQuery({

--- a/src/services/equipo.ts
+++ b/src/services/equipo.ts
@@ -12,6 +12,7 @@ import type { RolTienda } from "@/store/sesion";
 export interface MiembroTienda {
   userId: string;
   email: string;
+  nombre: string;
   rol: RolTienda;
   creadoAt: Date;
 }
@@ -30,6 +31,7 @@ export interface InvitacionTienda {
 interface MiembroRow {
   user_id: string;
   email: string;
+  nombre: string;
   rol: RolTienda;
   creado_at: string;
 }
@@ -76,9 +78,33 @@ export async function listarMiembros(
   return ((data ?? []) as MiembroRow[]).map((row) => ({
     userId: row.user_id,
     email: row.email,
+    nombre: row.nombre,
     rol: row.rol,
     creadoAt: new Date(row.creado_at),
   }));
+}
+
+/** Nombre propio (tabla perfiles): lo ven los compañeros en la atribución
+ * de items y listas. */
+export async function obtenerMiNombre(userId: string): Promise<string> {
+  const { data, error } = await supabase
+    .from("perfiles")
+    .select("nombre")
+    .eq("user_id", userId)
+    .single();
+  if (error) throw error;
+  return data.nombre as string;
+}
+
+export async function actualizarMiNombre(
+  userId: string,
+  nombre: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("perfiles")
+    .update({ nombre: nombre.trim() })
+    .eq("user_id", userId);
+  if (error) throw error;
 }
 
 export async function cambiarRolMiembro(

--- a/src/services/reposicion.ts
+++ b/src/services/reposicion.ts
@@ -26,6 +26,8 @@ interface ListaHistorialRow {
   total_pendientes: number;
   duracion_minutos: number | null;
   ubicacion: string | null;
+  // Embed de PostgREST vía la FK guardada_por → perfiles (0017).
+  perfiles?: { nombre: string } | null;
 }
 
 interface ItemHistorialRow {
@@ -76,6 +78,7 @@ function mapLista(
       totalPendientes: row.total_pendientes,
     },
     items: items.map(mapItemHistorial),
+    guardadaPorNombre: row.perfiles?.nombre ?? undefined,
     metadata: {
       duracionMinutos: row.duracion_minutos ?? undefined,
       ubicacion: row.ubicacion ?? undefined,
@@ -201,7 +204,7 @@ export async function obtenerHistorial(
 ): Promise<ListaReposicionHistorial[]> {
   let query = supabase
     .from("listas_reposicion_historial")
-    .select("*")
+    .select("*, perfiles(nombre)")
     .eq("tienda_id", tiendaId)
     .order("fecha_guardado", { ascending: false });
 

--- a/src/services/vencimiento.ts
+++ b/src/services/vencimiento.ts
@@ -16,6 +16,9 @@ interface ItemVencimientoRow {
   estado: "pendiente" | "retirado";
   agregado_at: string;
   resuelto_at: string | null;
+  // Embed de PostgREST vía la FK agregado_por → perfiles (0017); solo
+  // presente en los selects que lo piden.
+  perfiles?: { nombre: string } | null;
 }
 
 interface ItemVencimientoHistorialRow {
@@ -42,6 +45,7 @@ function mapItem(row: ItemVencimientoRow): ItemVencimiento {
     estado: row.estado,
     agregadoAt: new Date(row.agregado_at),
     resueltoAt: row.resuelto_at ? new Date(row.resuelto_at) : undefined,
+    agregadoPorNombre: row.perfiles?.nombre ?? undefined,
   };
 }
 
@@ -72,7 +76,7 @@ function mapHistorial(row: ItemVencimientoHistorialRow): ItemVencimientoHistoria
 export async function listarItems(tiendaId: string): Promise<ItemVencimientoConAlerta[]> {
   const { data, error } = await supabase
     .from("items_vencimiento")
-    .select("*")
+    .select("*, perfiles(nombre)")
     .eq("tienda_id", tiendaId)
     .eq("estado", "pendiente")
     .order("fecha_vencimiento", { ascending: true });

--- a/src/tests/integration/aislamiento-rls.test.ts
+++ b/src/tests/integration/aislamiento-rls.test.ts
@@ -295,13 +295,19 @@ describe("invitaciones y multi-membresía", () => {
     }
   });
 
-  it("multi-membresía: guardar la lista de A no toca los items de B", async () => {
-    // B (ahora miembro de A y de B) tiene pendientes en ambas tiendas.
-    const { error: aggError } = await userB.client.rpc("agregar_item_reposicion", {
+  it("multi-membresía + privacidad: guardar la lista de A archiva SOLO lo propio", async () => {
+    // B (ahora miembro de A y de B) tiene pendientes propios en ambas
+    // tiendas; A además tiene el item de la admin (invisible para B).
+    const { error: aggAError } = await userB.client.rpc("agregar_item_reposicion", {
+      p_variante_id: varianteA,
+      p_cantidad: 3,
+    });
+    expect(aggAError).toBeNull();
+    const { error: aggBError } = await userB.client.rpc("agregar_item_reposicion", {
       p_variante_id: varianteB,
       p_cantidad: 5,
     });
-    expect(aggError).toBeNull();
+    expect(aggBError).toBeNull();
 
     const { error: guardarError } = await userB.client.rpc(
       "guardar_lista_reposicion",
@@ -309,13 +315,20 @@ describe("invitaciones y multi-membresía", () => {
     );
     expect(guardarError).toBeNull();
 
-    // Los items de A se archivaron…
-    const { data: itemsA } = await userB.client
+    // Los items PROPIOS de B en A se archivaron…
+    const { data: itemsBenA } = await userB.client
       .from("items_reposicion")
       .select("id")
       .eq("tienda_id", tiendaA);
-    expect(itemsA).toEqual([]);
-    // …y los de B siguen pendientes (el WHERE por tienda de la RPC).
+    expect(itemsBenA).toEqual([]);
+    // …los de la admin en A siguen pendientes (lista privada por usuario)…
+    const { data: itemsAdminA } = await userA.client
+      .from("items_reposicion")
+      .select("id")
+      .eq("tienda_id", tiendaA);
+    expect(itemsAdminA).toHaveLength(1);
+    expect(itemsAdminA![0].id).toBe(itemReposicionA);
+    // …y los de B en la tienda B siguen intactos (el WHERE por tienda).
     const { data: itemsB } = await userB.client
       .from("items_reposicion")
       .select("id")
@@ -355,22 +368,117 @@ describe("invitaciones y multi-membresía", () => {
   });
 });
 
-describe("gestión de equipo (Fase 3, migración 0016)", () => {
+describe("privacidad de la lista de reposición (migración 0017)", () => {
+  // Estado heredado: A tiene a userA (admin, con un item pendiente) y a
+  // userB (empleado, sin items en A tras el guardado anterior).
+
+  it("un miembro no ve, edita ni borra los items pendientes de otro", async () => {
+    const { data: visibles } = await userB.client
+      .from("items_reposicion")
+      .select("id")
+      .eq("id", itemReposicionA);
+    expect(visibles).toEqual([]);
+
+    const { data: actualizados } = await userB.client
+      .from("items_reposicion")
+      .update({ cantidad: 99 })
+      .eq("id", itemReposicionA)
+      .select();
+    expect(actualizados).toEqual([]);
+
+    const { data: borrados } = await userB.client
+      .from("items_reposicion")
+      .delete()
+      .eq("id", itemReposicionA)
+      .select();
+    expect(borrados).toEqual([]);
+  });
+
+  it("no se puede insertar un item a nombre de otro (WITH CHECK)", async () => {
+    const { error } = await userB.client.from("items_reposicion").insert({
+      variante_id: varianteA,
+      cantidad: 1,
+      agregado_por: userA.id,
+    });
+    expect(error).not.toBeNull();
+  });
+
+  it("dos usuarios pueden tener la misma variante pendiente (unicidad por usuario)", async () => {
+    // Ana ya tiene varianteA pendiente; B agrega la suya sin mergear la ajena.
+    const { data, error } = await userB.client.rpc("agregar_item_reposicion", {
+      p_variante_id: varianteA,
+      p_cantidad: 1,
+    });
+    expect(error).toBeNull();
+    expect((data as { id: string }).id).not.toBe(itemReposicionA);
+
+    // El item de Ana quedó como estaba (cantidad 2, sin merge cruzado).
+    const { data: deAna } = await userA.client
+      .from("items_reposicion")
+      .select("cantidad")
+      .eq("id", itemReposicionA)
+      .single();
+    expect(deAna!.cantidad).toBe(2);
+
+    // Limpieza: B borra su propio item.
+    await userB.client
+      .from("items_reposicion")
+      .delete()
+      .eq("id", (data as { id: string }).id);
+  });
+
+  it("los nombres de perfil son visibles entre compañeros de tienda", async () => {
+    const { data, error } = await userB.client
+      .from("perfiles")
+      .select("nombre")
+      .eq("user_id", userA.id);
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data![0].nombre).toBe(userA.email.split("@")[0]);
+  });
+});
+
+describe("gestión de equipo (Fase 3, migraciones 0016/0017)", () => {
   // Estado heredado del describe anterior: A tiene a userA (admin) y a
   // userB (empleado, vía canje); B tiene solo a userB (admin).
 
-  it("miembros_de_tienda devuelve los emails a un miembro", async () => {
-    const { data, error } = await userB.client.rpc("miembros_de_tienda", {
+  it("miembros_de_tienda es admin-only: el admin ve nombres y emails", async () => {
+    const { data, error } = await userA.client.rpc("miembros_de_tienda", {
       p_tienda_id: tiendaA,
     });
     expect(error).toBeNull();
-    const miembros = data as { user_id: string; email: string; rol: string }[];
+    const miembros = data as {
+      user_id: string;
+      email: string;
+      nombre: string;
+      rol: string;
+    }[];
     expect(miembros).toHaveLength(2);
     expect(miembros.map((m) => m.email)).toEqual(
       expect.arrayContaining([userA.email, userB.email])
     );
     expect(miembros.find((m) => m.user_id === userA.id)?.rol).toBe("admin");
     expect(miembros.find((m) => m.user_id === userB.id)?.rol).toBe("empleado");
+    expect(miembros.find((m) => m.user_id === userB.id)?.nombre).toBe(
+      userB.email.split("@")[0]
+    );
+  });
+
+  it("miembros_de_tienda devuelve vacío a un empleado", async () => {
+    const { data, error } = await userB.client.rpc("miembros_de_tienda", {
+      p_tienda_id: tiendaA,
+    });
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+
+  it("un empleado no enumera las membresías ajenas de su tienda", async () => {
+    const { data } = await userB.client
+      .from("tienda_miembros")
+      .select("user_id")
+      .eq("tienda_id", tiendaA);
+    expect(data).toHaveLength(1);
+    expect(data![0].user_id).toBe(userB.id);
   });
 
   it("miembros_de_tienda de una tienda ajena devuelve vacío", async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,7 @@ export interface ItemVencimiento {
   estado: EstadoVencimiento;
   agregadoAt: Date;
   resueltoAt?: Date;
+  agregadoPorNombre?: string; // Nombre del perfil de quien lo registró (0017)
 }
 
 // Item de vencimiento con el nivel de alerta calculado al leer
@@ -143,6 +144,7 @@ export interface ListaReposicionHistorial {
     totalPendientes: number;
   };
   items: ItemHistorial[];
+  guardadaPorNombre?: string; // Nombre del perfil de quien la guardó (0017)
   metadata: {
     duracionMinutos?: number; // Tiempo que tomó completar la lista
     ubicacion?: string; // Opcional: góndola/sección

--- a/supabase/migrations/0017_perfiles_y_privacidad.sql
+++ b/supabase/migrations/0017_perfiles_y_privacidad.sql
@@ -1,0 +1,237 @@
+-- Fase 3.1: perfiles con nombre, privacidad de la lista de reposición y
+-- hardening de equipo. Responde a los hallazgos del testing real de la
+-- Fase 3:
+--
+-- 1. Cada usuario tiene un nombre visible (tabla perfiles) para atribuir
+--    listas e items ("quién agregó/guardó esto").
+-- 2. La lista de reposición ACTIVA pasa a ser privada por usuario
+--    (agregado_por + RLS): nadie ve los items pendientes de otro hasta
+--    que se guardan — el historial sigue siendo compartido de la tienda.
+-- 3. El equipo deja de ser enumerable por empleados: tienda_miembros solo
+--    muestra la fila propia (o todas si sos admin) y miembros_de_tienda
+--    pasa a ser admin-only.
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Perfiles
+-- ─────────────────────────────────────────────────────────────────────────
+
+create table perfiles (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  nombre text not null check (length(trim(nombre)) between 1 and 60),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger trg_perfiles_updated_at
+  before update on perfiles
+  for each row execute function set_updated_at();
+
+alter table perfiles enable row level security;
+
+-- Compañeros de cualquier tienda compartida. DEFINER: la policy de
+-- perfiles no puede subconsultar tienda_miembros como invoker porque su
+-- select ahora es propio-o-admin (un empleado no vería a sus compañeros).
+create or replace function mis_companeros() returns setof uuid
+language sql stable security definer set search_path = public as
+$$
+  select distinct tm.user_id from tienda_miembros tm
+  where tm.tienda_id in (
+    select tienda_id from tienda_miembros where user_id = (select auth.uid())
+  )
+$$;
+
+revoke execute on function mis_companeros() from public, anon;
+grant execute on function mis_companeros() to authenticated, service_role;
+
+-- El nombre es visible entre compañeros de tienda (atribución de items);
+-- el email NO viaja por acá (eso queda en miembros_de_tienda, admin-only).
+create policy "perfiles_select_companeros" on perfiles
+  for select to authenticated
+  using (user_id in (select mis_companeros()) or user_id = (select auth.uid()));
+create policy "perfiles_insert_propio" on perfiles
+  for insert to authenticated
+  with check (user_id = (select auth.uid()));
+create policy "perfiles_update_propio" on perfiles
+  for update to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+-- Backfill de los usuarios existentes: metadata del signup o local-part
+-- del email.
+insert into perfiles (user_id, nombre)
+select
+  id,
+  coalesce(
+    nullif(trim(raw_user_meta_data->>'nombre'), ''),
+    nullif(split_part(email, '@', 1), ''),
+    'Usuario'
+  )
+from auth.users
+on conflict (user_id) do nothing;
+
+-- Alta automática para los usuarios futuros (patrón handle_new_user).
+create or replace function crear_perfil_de_usuario() returns trigger
+language plpgsql security definer set search_path = public as $$
+begin
+  insert into perfiles (user_id, nombre)
+  values (
+    new.id,
+    coalesce(
+      nullif(trim(new.raw_user_meta_data->>'nombre'), ''),
+      nullif(split_part(new.email, '@', 1), ''),
+      'Usuario'
+    )
+  )
+  on conflict (user_id) do nothing;
+  return new;
+end; $$;
+
+create trigger trg_crear_perfil_de_usuario
+  after insert on auth.users
+  for each row execute function crear_perfil_de_usuario();
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Atribución: agregado_por / guardada_por
+--    Referencian perfiles (no auth.users) para que PostgREST pueda embeber
+--    el nombre en un solo select. Backfill: el admin más antiguo de la
+--    tienda (único autor posible de lo pre-existente).
+-- ─────────────────────────────────────────────────────────────────────────
+
+alter table items_reposicion
+  add column agregado_por uuid references perfiles(user_id) on delete cascade
+  default auth.uid();
+
+update items_reposicion ir set agregado_por = (
+  select tm.user_id from tienda_miembros tm
+  where tm.tienda_id = ir.tienda_id and tm.rol = 'admin'
+  order by tm.created_at limit 1
+) where agregado_por is null;
+
+alter table items_reposicion alter column agregado_por set not null;
+create index idx_items_reposicion_agregado_por on items_reposicion (agregado_por);
+
+alter table items_vencimiento
+  add column agregado_por uuid references perfiles(user_id) on delete set null
+  default auth.uid();
+
+update items_vencimiento iv set agregado_por = (
+  select tm.user_id from tienda_miembros tm
+  where tm.tienda_id = iv.tienda_id and tm.rol = 'admin'
+  order by tm.created_at limit 1
+) where agregado_por is null;
+
+alter table listas_reposicion_historial
+  add column guardada_por uuid references perfiles(user_id) on delete set null
+  default auth.uid();
+
+update listas_reposicion_historial lr set guardada_por = (
+  select tm.user_id from tienda_miembros tm
+  where tm.tienda_id = lr.tienda_id and tm.rol = 'admin'
+  order by tm.created_at limit 1
+) where guardada_por is null;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. La lista activa de reposición es privada por usuario. El WITH CHECK
+--    con auth.uid() impide insertar a nombre de otro; la membresía sigue
+--    exigida (un expulsado pierde acceso aunque los items sean suyos).
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop policy "items_reposicion_select_miembros" on items_reposicion;
+drop policy "items_reposicion_insert_miembros" on items_reposicion;
+drop policy "items_reposicion_update_miembros" on items_reposicion;
+drop policy "items_reposicion_delete_miembros" on items_reposicion;
+
+create policy "items_reposicion_select_propio" on items_reposicion
+  for select to authenticated
+  using (agregado_por = (select auth.uid()) and tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_insert_propio" on items_reposicion
+  for insert to authenticated
+  with check (agregado_por = (select auth.uid()) and tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_update_propio" on items_reposicion
+  for update to authenticated
+  using (agregado_por = (select auth.uid()) and tienda_id in (select mis_tiendas()))
+  with check (agregado_por = (select auth.uid()) and tienda_id in (select mis_tiendas()));
+create policy "items_reposicion_delete_propio" on items_reposicion
+  for delete to authenticated
+  using (agregado_por = (select auth.uid()) and tienda_id in (select mis_tiendas()));
+
+-- Con listas privadas, dos usuarios pueden tener la misma variante
+-- pendiente a la vez: la unicidad pasa a (usuario, variante).
+drop index items_reposicion_pendiente_por_variante_uq;
+create unique index items_reposicion_pendiente_por_usuario_uq
+  on items_reposicion (agregado_por, variante_id) where estado = 'pendiente';
+
+-- Mismo cuerpo que 0015; solo cambia el target del ON CONFLICT al índice
+-- nuevo (agregado_por sale del DEFAULT auth.uid()). El UPDATE del merge ya
+-- queda scopeado a los items propios vía RLS (invoker).
+create or replace function agregar_item_reposicion(p_variante_id uuid, p_cantidad int)
+returns items_reposicion
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_item items_reposicion%rowtype;
+begin
+  update items_reposicion
+  set cantidad = cantidad + p_cantidad,
+      estado = 'pendiente'
+  where id = (
+    select id
+    from items_reposicion
+    where variante_id = p_variante_id
+    order by (estado = 'pendiente') desc, agregado_at desc
+    limit 1
+  )
+  returning * into v_item;
+
+  if found then
+    return v_item;
+  end if;
+
+  insert into items_reposicion (variante_id, cantidad, estado)
+  values (p_variante_id, p_cantidad, 'pendiente')
+  on conflict (agregado_por, variante_id) where estado = 'pendiente'
+  do update set cantidad = items_reposicion.cantidad + excluded.cantidad
+  returning * into v_item;
+
+  return v_item;
+end;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 4. Equipo: los empleados no enumeran miembros; la lista con emails es
+--    exclusiva de admins (la UI de /tienda pasa a ser admin-only).
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop policy "tienda_miembros_select_miembros" on tienda_miembros;
+create policy "tienda_miembros_select_propio_o_admin" on tienda_miembros
+  for select to authenticated
+  using (
+    user_id = (select auth.uid())
+    or tienda_id in (select mis_tiendas_admin())
+  );
+
+drop function miembros_de_tienda(uuid);
+create function miembros_de_tienda(p_tienda_id uuid)
+returns table (user_id uuid, email text, nombre text, rol text, creado_at timestamptz)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select tm.user_id, u.email::text, coalesce(p.nombre, split_part(u.email, '@', 1)), tm.rol, tm.created_at
+  from tienda_miembros tm
+  join auth.users u on u.id = tm.user_id
+  left join perfiles p on p.user_id = tm.user_id
+  where tm.tienda_id = p_tienda_id
+    and p_tienda_id in (
+      select tienda_id from tienda_miembros
+      where tienda_miembros.user_id = (select auth.uid())
+        and tienda_miembros.rol = 'admin'
+    )
+  order by tm.created_at;
+$$;
+
+revoke execute on function miembros_de_tienda(uuid) from public, anon;
+grant execute on function miembros_de_tienda(uuid) to authenticated, service_role;


### PR DESCRIPTION
Resuelve los **4 hallazgos del testing real** de la Fase 3.

## 🐛 Fix crítico: un empleado podía adoptar rol admin en la UI (issue 4)

`AuthProvider` resolvía la membresía **sin filtrar por `user_id`**: RLS le muestra a un miembro las filas de toda su tienda, así que `data[0]` podía ser la fila del admin y el empleado adoptaba `rol: "admin"` en la UI — veía el botón "Eliminar esta lista" y las affordances de admin (los writes igual los bloqueaba RLS server-side). El bug era invisible hasta que una tienda tuvo su segundo miembro. Fix: `.eq("user_id", uid)`.

## Migración `0017_perfiles_y_privacidad.sql` (⚠️ NO se aplica con este merge)

- **Perfiles con nombre** (issue 1): tabla `perfiles(user_id, nombre)` con alta automática vía trigger en `auth.users` (patrón handle_new_user) + backfill. Nombres visibles solo **entre compañeros de tienda**; edición solo propia. El email no viaja por acá.
- **Lista de reposición privada** (issue 3): `agregado_por not null` (backfill al admin más antiguo) + policies por usuario — nadie ve/edita/borra los items pendientes de otro **hasta que se guardan**; el historial sigue compartido. La unicidad de pendientes pasa a `(agregado_por, variante_id)` — dos personas pueden tener la misma variante pendiente — y `agregar_item_reposicion` cambia su `ON CONFLICT` al índice nuevo. `guardar_lista_reposicion` archiva solo lo del caller (invoker + RLS, sin cambio de firma).
- **Atribución** (issue 1): `agregado_por` en `items_vencimiento` y `guardada_por` en `listas_reposicion_historial`, con FK a `perfiles` para embeber el nombre en un solo select de PostgREST.
- **Equipo admin-only** (issue 2, server-side): `tienda_miembros` select propio-o-admin (un empleado ya no enumera al equipo) y `miembros_de_tienda` pasa a admin-only (ahora devuelve también el nombre).

## Cliente

- `/registro` pide **tu nombre** (va en `user_metadata`; el trigger crea el perfil).
- **`/perfil`** nueva (ícono 👤 en el header, para todos): editar nombre, ver tienda y rol, **salir de la tienda** (se muda desde `/tienda`) y **cerrar sesión** (se muda del header).
- **`/tienda` solo admin** (issue 2): gate client-side + el ícono 🏪 del header solo se muestra a admins; el equipo lista nombre + email.
- Atribución visible: "por {nombre}" en cada item de vencimiento y "· por {nombre}" en las listas del historial de reposición.

## Tests

Suite de integración actualizada a la nueva semántica: guardar archiva **solo lo propio** (multi-membresía + privacidad), privacidad entre miembros de la misma tienda, misma variante pendiente para dos usuarios, `WITH CHECK` de `agregado_por` (no se inserta a nombre de otro), perfiles entre compañeros, `miembros_de_tienda` admin-only. **172/172 unit verdes**, `tsc` limpio, lint sin errores nuevos, `next build` OK.

## Deploy

La 0017 debe aplicarse **antes** del deploy del cliente (el cliente nuevo embebe `perfiles(nombre)` y necesita las tablas). Es compatible con el cliente viejo (columnas nuevas con default; la RLS más estricta solo reduce lo visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW)_