### PR TITLE
Fase 4: colaboración en vivo (refetch al foco + realtime por tienda)

### DIFF
--- a/docs/RUNBOOK-MULTITIENDA.md
+++ b/docs/RUNBOOK-MULTITIENDA.md
@@ -1,0 +1,128 @@
+# Runbook operativo — multi-tienda
+
+Operación día a día del sistema multi-tienda (Fases 1–4 de
+`docs/SPECMULTIUSER.md`). Para el detalle del deploy coordinado de la Fase 1
+ver `docs/DEPLOY-FASE1.md`; este doc cubre la operación una vez que todo
+está en producción.
+
+Proyectos Supabase:
+- **Producción**: `naccvajxoxosdmehvgnk`
+- **Espejo/staging**: `zjoptonaowtcsfgdfgfb` (para ensayar migraciones y correr
+  la verificación de aislamiento por SQL antes de tocar producción).
+
+---
+
+## Modelo de acceso (resumen)
+
+- **Tienda**: unidad de aislamiento. Todo dato (`producto_bases`,
+  `producto_variantes`, `items_*`, historial, `categoria_atributos`) lleva
+  `tienda_id` y está protegido por RLS por membresía.
+- **Membresía** (`tienda_miembros`): un usuario pertenece a ≥1 tienda con rol
+  `admin` o `empleado`.
+- **Perfil** (`perfiles`): nombre visible del usuario, para atribuir listas e
+  items. Se crea solo al registrarse.
+- **Roles**:
+  - *Empleado*: opera reposición (lista **privada** por usuario) y
+    vencimientos (compartidos), ve el catálogo y el historial.
+  - *Admin*: además renombra la tienda, gestiona el equipo y las
+    invitaciones, borra historial y catálogo, y gestiona
+    `categoria_atributos`.
+- **Invariante "último admin"**: una tienda nunca puede quedarse sin admin
+  (trigger `proteger_ultimo_admin`).
+
+---
+
+## Tareas frecuentes
+
+### Sumar un empleado a la tienda
+Se hace **desde la app**, sin tocar el dashboard:
+1. Un admin entra a **/tienda → Generar código** (elige rol y cantidad de
+   usos; vence a los 7 días) y comparte el código o el link
+   `/unirse?codigo=XXXX`.
+2. El nuevo usuario abre el link, crea su cuenta (con su nombre) y queda
+   dentro. Si ya tenía cuenta, la usa.
+3. Revocar un código: **/tienda**, botón ✕ sobre el código.
+
+### Cambiar el rol o expulsar a alguien
+**/tienda → Equipo**: "Hacer admin / Hacer empleado" o el ícono de quitar.
+La expulsión corta el acceso **en el próximo request online** del expulsado;
+su copia local ya descargada no es revocable (limitación aceptada del
+offline-first, ver spec §"Limitaciones declaradas").
+
+### Alta manual de un usuario (excepcional)
+Solo si hace falta crear una cuenta sin signup público. Dashboard →
+Authentication → Add user; después, para darle membresía admin de la tienda
+inicial:
+```sql
+insert into tienda_miembros (tienda_id, user_id, rol)
+values ('<tienda_id>', '<user_id>', 'admin');
+```
+El perfil se crea solo por el trigger `trg_crear_perfil_de_usuario` (nombre
+derivado del email; el usuario lo edita en /perfil).
+
+### Crear una tienda nueva
+Se autogestiona: una cuenta nueva sin membresía cae en `/onboarding` y elige
+"Crear mi tienda" (RPC `crear_tienda_con_admin`, queda como admin).
+
+---
+
+## Deploy de una migración
+
+1. Escribir `supabase/migrations/00NN_*.sql`.
+2. **Ensayo en el espejo** vía MCP `apply_migration` (proyecto
+   `zjoptonaowtcsfgdfgfb`); correr la verificación de aislamiento por SQL
+   (impersonando usuarios con `set_config('request.jwt.claims', …)` +
+   `set role authenticated`), mirroring de `src/tests/integration/aislamiento-rls.test.ts`.
+3. Correr `get_advisors` (security) en el espejo.
+4. Aplicar la misma migración a **producción** y, si el cliente depende de
+   ella, mergear el PR para disparar el deploy de Vercel.
+
+**Orden migración ↔ deploy** (crítico en las fases con cambios de firma):
+- **Cambios de firma de RPC** (Fase 2): migración y deploy **juntos**, en una
+  ventana corta con la tienda tranquila (las firmas cruzadas son
+  incompatibles en ambos sentidos).
+- **Cambios aditivos** (columnas nuevas con default, tablas nuevas, RPC
+  nuevas — Fases 3, 3.1, 4): aplicar la **migración primero**, después el
+  deploy. El cliente viejo convive con las columnas nuevas.
+
+---
+
+## Rollback de emergencia
+
+- **Cliente**: `vercel rollback` (o "Promote" del deployment previo en el
+  dashboard) — restaura la versión anterior en segundos.
+- **Migración**: no hay `down` automático. Para revertir, escribir la
+  migración inversa. El caso más delicado ya deployado y con runbook propio
+  es el corte de `anon` de la Fase 1 (recrear `allow_all_anon` + re-grant de
+  las RPCs a `anon`): ver `docs/DEPLOY-FASE1.md`.
+
+---
+
+## Colaboración en vivo (Fase 4)
+
+- Las listas activas refetchean al volver el foco a la pestaña y cada 30 s
+  (solo con la pestaña visible).
+- Un canal `postgres_changes` por tienda (`RealtimeProvider`) invalida las
+  listas cuando cambian en el server: vencimientos se propagan a toda la
+  tienda; reposición —privada— solo entre dispositivos de la misma cuenta.
+- La publication `supabase_realtime` incluye `items_reposicion` e
+  `items_vencimiento` (migración 0018) y ambas tienen `REPLICA IDENTITY FULL`
+  (necesario para que los eventos DELETE lleguen con `tienda_id`).
+- Si el realtime se cae, el refetch por foco/intervalo es el fallback: la
+  colaboración degrada a "hasta 30 s", no se rompe.
+
+---
+
+## Chequeos de salud
+
+- **Advisors de seguridad** (dashboard o MCP `get_advisors`): tras cada
+  migración. Los WARN esperados son las funciones `SECURITY DEFINER` con
+  guard interno (`crear_tienda_con_admin`, `canjear_invitacion`,
+  `generar_codigo_invitacion`, `mis_tiendas*`, `mis_companeros`,
+  `miembros_de_tienda`) y "Leaked Password Protection" si se desactivara.
+- **Sin filas sin `tienda_id`/`agregado_por`**: no debería haber (columnas
+  `not null`); si aparecen tras un import manual, backfillear antes de que la
+  RLS las vuelva invisibles.
+- **Signups públicos**: habilitados desde la Fase 3 (Authentication → Sign
+  In / Providers). Una cuenta nueva sin membresía no ve ningún dato y cae en
+  el onboarding.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { AuthProvider } from "@/components/AuthProvider";
 import CatalogoSyncProvider from "@/components/CatalogoSyncProvider";
 import OutboxProvider from "@/components/OutboxProvider";
+import RealtimeProvider from "@/components/RealtimeProvider";
 import PWAProvider from "./PWAProvider";
 import { QueryProvider } from "./QueryProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -109,6 +110,7 @@ export default function RootLayout({
           <ThemeProvider>
             <PWAProvider />
             <OutboxProvider />
+            <RealtimeProvider />
             <CatalogoSyncProvider />
             <Toaster
               position="top-center"

--- a/src/components/RealtimeProvider.tsx
+++ b/src/components/RealtimeProvider.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useAuth } from "@/components/AuthProvider";
+import { reposicionItemsKey, vencimientoItemsKey } from "@/lib/queryKeys";
+import { supabase } from "@/lib/supabase";
+import { useOutboxStore } from "@/store/outbox";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+/**
+ * Colaboración en vivo (docs/SPECMULTIUSER.md §7): un canal
+ * `postgres_changes` por tienda que INVALIDA las listas activas cuando
+ * cambian en el servidor. Complementa el refetch al foco / por intervalo
+ * de los hooks con propagación casi inmediata entre dispositivos.
+ *
+ * Reglas del diseño (§7), para no chocar con optimistic updates + outbox:
+ * - Solo invalida la query; nunca aplica el payload al cache (evita el eco
+ *   de las propias mutaciones y los conflictos con lo optimista).
+ * - Debounce (una ráfaga de N cambios = una sola invalidación).
+ * - Suspende mientras el outbox sincroniza (su corrida ya invalida al
+ *   final): así una tanda de escrituras propias no dispara refetches
+ *   redundantes.
+ *
+ * RLS aplica al canal con el token authenticated: `items_vencimiento`
+ * llega a toda la tienda; `items_reposicion` —privada por usuario desde la
+ * 0017— solo al propio dueño (multi-dispositivo con la misma cuenta).
+ */
+const DEBOUNCE_MS = 400;
+
+export default function RealtimeProvider() {
+  const queryClient = useQueryClient();
+  const { tiendaActiva } = useAuth();
+
+  useEffect(() => {
+    if (!tiendaActiva) return;
+
+    const timers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+    const invalidarDebounced = (key: readonly unknown[]) => {
+      const id = JSON.stringify(key);
+      clearTimeout(timers[id]);
+      timers[id] = setTimeout(() => {
+        // El outbox invalida ["tienda"] al terminar su corrida; mientras
+        // sincroniza, dejamos que él sea la fuente de verdad.
+        if (useOutboxStore.getState().isSyncing) return;
+        queryClient.invalidateQueries({ queryKey: key });
+      }, DEBOUNCE_MS);
+    };
+
+    const filtro = `tienda_id=eq.${tiendaActiva}`;
+    const canal = supabase
+      .channel(`tienda:${tiendaActiva}`)
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "items_reposicion", filter: filtro },
+        () => invalidarDebounced(reposicionItemsKey(tiendaActiva))
+      )
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "items_vencimiento", filter: filtro },
+        () => invalidarDebounced(vencimientoItemsKey(tiendaActiva))
+      );
+
+    // El canal necesita el JWT del usuario para que RLS filtre lo que emite.
+    // Se re-setea en cada refresh de token (si no, el canal se queda con un
+    // access token vencido tras ~1 h y deja de recibir).
+    let cancelado = false;
+    supabase.auth.getSession().then(({ data }) => {
+      if (cancelado) return;
+      if (data.session?.access_token) {
+        supabase.realtime.setAuth(data.session.access_token);
+      }
+      canal.subscribe();
+    });
+
+    const { data: authSub } = supabase.auth.onAuthStateChange((_e, session) => {
+      if (session?.access_token) supabase.realtime.setAuth(session.access_token);
+    });
+
+    return () => {
+      cancelado = true;
+      authSub.subscription.unsubscribe();
+      Object.values(timers).forEach(clearTimeout);
+      supabase.removeChannel(canal);
+    };
+  }, [queryClient, tiendaActiva]);
+
+  return null;
+}

--- a/src/components/__tests__/RealtimeProvider.test.tsx
+++ b/src/components/__tests__/RealtimeProvider.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Captura los handlers de postgres_changes por tabla para dispararlos a mano.
+const handlers: Record<string, () => void> = {};
+interface CanalFake {
+  on: (ev: string, cfg: { table: string }, cb: () => void) => CanalFake;
+  subscribe: () => CanalFake;
+}
+const canalFake: CanalFake = {
+  on: vi.fn((_ev: string, cfg: { table: string }, cb: () => void) => {
+    handlers[cfg.table] = cb;
+    return canalFake;
+  }),
+  subscribe: vi.fn(() => canalFake),
+};
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    channel: vi.fn(() => canalFake),
+    removeChannel: vi.fn(),
+    realtime: { setAuth: vi.fn() },
+    auth: {
+      getSession: vi.fn(async () => ({
+        data: { session: { access_token: "jwt-test" } },
+      })),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+    },
+  },
+}));
+
+vi.mock("@/components/AuthProvider", () => ({
+  useAuth: () => ({ tiendaActiva: "tienda-test" }),
+}));
+
+import RealtimeProvider from "@/components/RealtimeProvider";
+import { useOutboxStore } from "@/store/outbox";
+
+const ITEMS_REPOSICION = ["tienda", "tienda-test", "reposicion", "items"];
+
+function renderProvider(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RealtimeProvider />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Object.keys(handlers).forEach((k) => delete handlers[k]);
+  useOutboxStore.setState({ isSyncing: false });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("RealtimeProvider", () => {
+  it("invalida la lista una sola vez tras una ráfaga (debounce)", async () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    renderProvider(queryClient);
+
+    // La suscripción espera a getSession() (promesa); dejarla resolver.
+    await vi.waitFor(() => expect(handlers.items_reposicion).toBeDefined());
+
+    handlers.items_reposicion();
+    handlers.items_reposicion();
+    handlers.items_reposicion();
+    expect(invalidateSpy).not.toHaveBeenCalled(); // aún en debounce
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ITEMS_REPOSICION });
+  });
+
+  it("suspende la invalidación mientras el outbox sincroniza", async () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    renderProvider(queryClient);
+    await vi.waitFor(() => expect(handlers.items_reposicion).toBeDefined());
+
+    useOutboxStore.setState({ isSyncing: true });
+    handlers.items_reposicion();
+    await vi.advanceTimersByTimeAsync(400);
+
+    // El outbox invalida ["tienda"] al terminar su corrida; acá no.
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useReposicion.tsx
+++ b/src/hooks/useReposicion.tsx
@@ -34,6 +34,11 @@ export function useReposicionItems() {
     queryKey: ITEMS_KEY,
     queryFn: () => reposicionService.listarItems(tiendaActiva!),
     enabled: !!tiendaActiva,
+    // Colaboración en vivo (Fase 4, §7): la lista es privada por usuario,
+    // así que esto sirve al caso multi-dispositivo con la misma cuenta.
+    // refetchIntervalInBackground default false → solo con pestaña visible.
+    refetchOnWindowFocus: true,
+    refetchInterval: 30_000,
   });
 }
 

--- a/src/hooks/useVencimiento.tsx
+++ b/src/hooks/useVencimiento.tsx
@@ -33,6 +33,12 @@ export function useVencimientoItems() {
     queryKey: ITEMS_KEY,
     queryFn: () => vencimientoService.listarItems(tiendaActiva!),
     enabled: !!tiendaActiva,
+    // Colaboración en vivo (Fase 4, §7): la lista de vencimientos es
+    // compartida por la tienda; refetch al foco + cada 30 s (solo con
+    // pestaña visible) trae los cambios de otros empleados. El realtime
+    // lo complementa con invalidación inmediata.
+    refetchOnWindowFocus: true,
+    refetchInterval: 30_000,
     // Re-deriva el nivel de alerta al leer: los datos pueden venir del
     // cache persistido (arranque offline) o de una app abierta toda la
     // noche, con un alertaNivel calculado días atrás.

--- a/supabase/migrations/0018_realtime_publication.sql
+++ b/supabase/migrations/0018_realtime_publication.sql
@@ -1,0 +1,45 @@
+-- Fase 4: colaboración en vivo (docs/SPECMULTIUSER.md §7). Suma las dos
+-- tablas de listas activas a la publication de realtime para que el canal
+-- postgres_changes las emita.
+--
+-- RLS aplica al canal con el token authenticated (setAuth en el cliente):
+-- items_vencimiento se comparte a toda la tienda, e items_reposicion —
+-- privada por usuario desde la 0017 — solo emite al propio dueño (útil en
+-- multi-dispositivo con la misma cuenta). El filtro tienda_id=eq.X del
+-- cliente acota además a la tienda activa.
+--
+-- El handler del cliente solo INVALIDA la query (nunca aplica el payload):
+-- por eso alcanza con el evento, sin exponer old/new completos.
+--
+-- REPLICA IDENTITY FULL: sin esto, el evento DELETE solo trae la PK y el
+-- filtro tienda_id=eq.X (y RLS) no puede evaluarse sobre la fila borrada,
+-- así que los DELETE (retirar vencimiento, quitar pendiente) no llegarían.
+-- Con FULL el old-record incluye todas las columnas. Costo de WAL menor:
+-- son tablas de bajo volumen.
+
+alter table items_reposicion replica identity full;
+alter table items_vencimiento replica identity full;
+
+-- Idempotente: en un stack recién creado por `supabase start`, la
+-- publication existe pero sin estas tablas; el DO evita el error si ya
+-- estuvieran (re-corridas, entornos distintos).
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'items_reposicion'
+  ) then
+    alter publication supabase_realtime add table items_reposicion;
+  end if;
+
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'items_vencimiento'
+  ) then
+    alter publication supabase_realtime add table items_vencimiento;
+  end if;
+end $$;


### PR DESCRIPTION
Implementa la **Fase 4** de `docs/SPECMULTIUSER.md` (§7) — la última del roadmap multi-tienda. Cierra el ciclo: dos dispositivos ven el cambio del otro en <2 s online, sin regresión del flujo offline.

## Quick win — refetch de las listas activas

`useReposicionItems` y `useVencimientoItems` ganan `refetchOnWindowFocus: true` + `refetchInterval: 30_000` (con `refetchIntervalInBackground` en su default `false` → solo refetchea con la pestaña visible). Cubre el grueso del valor colaborativo con pocas líneas y es el **fallback** si el realtime se cae (degrada a "hasta 30 s", no se rompe).

## Realtime — `RealtimeProvider`

Un canal `postgres_changes` por tienda (`tienda_id=eq.X`) sobre `items_reposicion` e `items_vencimiento`, montado en el layout. Diseño alineado a §7 para no chocar con optimistic updates + outbox:

- El handler **solo invalida** la query correspondiente — nunca aplica el payload al cache (evita el eco de las propias mutaciones y los conflictos con lo optimista).
- **Debounce 400 ms**: una ráfaga de N cambios = una sola invalidación.
- **Suspende mientras el outbox sincroniza** (`useOutboxStore.isSyncing`): su corrida ya invalida `["tienda"]` al final.
- `setAuth` con el JWT de sesión (re-set en cada refresh de token) para que **RLS filtre lo que emite el canal**: `items_vencimiento` llega a toda la tienda; `items_reposicion` —privada desde la 0017— solo al propio dueño (multi-dispositivo con la misma cuenta).

## Migración `0018_realtime_publication.sql` (⚠️ NO se aplica con este merge)

- Suma las dos tablas a la publication `supabase_realtime` (idempotente).
- **`REPLICA IDENTITY FULL`** en ambas: sin esto el evento DELETE solo trae la PK y el filtro `tienda_id`/RLS no puede evaluarse, así que los DELETE (retirar vencimiento, quitar pendiente) no llegarían. Costo de WAL menor — tablas de bajo volumen.

## Runbook operativo — `docs/RUNBOOK-MULTITIENDA.md`

Modelo de acceso, tareas frecuentes (invitar, roles, alta manual, crear tienda), orden migración↔deploy (aditivo vs. cambio de firma), rollback de emergencia y chequeos de salud.

## Tests

Dos tests nuevos del `RealtimeProvider` (la parte delicada): el **debounce** (ráfaga → una invalidación) y el **gating por `isSyncing`** (no invalida mientras el outbox corre). **174/174 unit verdes**, `tsc` limpio, lint sin errores nuevos, `next build` OK. Publication + `REPLICA IDENTITY FULL` confirmadas en el espejo.

## Deploy

Aditivo: aplicar la **0018 primero**, después el merge/deploy. El cliente viejo convive sin problema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGW7jJSn8FUcTFJhEgENW)_