### PR TITLE
Agregar chips de cantidad 24 y 48 en QuickAdjustCard

### DIFF
--- a/src/components/scanner/QuickAdjustCard.tsx
+++ b/src/components/scanner/QuickAdjustCard.tsx
@@ -17,7 +17,7 @@ export interface QuickAdjustCardProps {
   onUndo: () => void;
 }
 
-const CHIPS = [2, 3, 6, 12];
+const CHIPS = [2, 3, 6, 12, 24, 48];
 
 /**
  * Card flotante sobre la cámara para ajustar la cantidad de un producto
@@ -101,7 +101,7 @@ export function QuickAdjustCard({
                 </m.button>
               </div>
 
-              <div className="flex items-center justify-center gap-2">
+              <div className="flex flex-wrap items-center justify-center gap-2">
                 {CHIPS.map((n) => (
                   <button
                     key={n}


### PR DESCRIPTION
## 📝 Descripción

Agrega los botones (chips) de cantidad rápida 24 y 48 en el `QuickAdjustCard`, la tarjeta flotante que aparece sobre la cámara del escáner para ajustar la cantidad de un producto recién auto-agregado.

- `CHIPS` pasa de `[2, 3, 6, 12]` a `[2, 3, 6, 12, 24, 48]` en `src/components/scanner/QuickAdjustCard.tsx`.
- La fila de chips ahora usa `flex-wrap` para que las nuevas opciones no se desborden en pantallas angostas (mismo patrón ya usado en `ExpiryQuickSheet.tsx`).

## 🎯 Tipo de cambio

- [ ] 🐛 Bug fix (cambio que corrige un problema)
- [x] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [ ] 💥 Breaking change (cambio que rompe compatibilidad)
- [ ] 📚 Documentación
- [x] 🎨 Mejora de UI/UX
- [ ] ⚡ Mejora de rendimiento
- [ ] ♻️ Refactorización

## 🔗 Issue relacionado

N/A

## 🧪 Testing

- [x] Tests existentes del scanner (`scanFlowMachine`, `ExpiryQuickSheet`) pasan
- [x] `tsc --noEmit` sin errores
- [x] `eslint` sin errores en el archivo modificado
- [ ] Probado manualmente en dispositivo móvil (no fue posible en este entorno)

## ✅ Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [x] Mis cambios no generan warnings nuevos
- [x] Los tests existentes pasan correctamente

## 🎯 Instrucciones de testing

1. Escanear o agregar manualmente un producto para abrir la tarjeta de ajuste rápido (`QuickAdjustCard`).
2. Verificar que aparezcan los chips 2, 3, 6, 12, 24 y 48.
3. Tocar 24 o 48 y confirmar que la cantidad se actualiza correctamente.

## 📌 Notas adicionales

Cambio mínimo y enfocado: solo se tocó `src/components/scanner/QuickAdjustCard.tsx`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv75h7zstrYoYze8iJEJ2X)_